### PR TITLE
Feat#8/be/workspace crud

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/passport": "^9.0.0",
         "@nestjs/platform-express": "^9.0.0",
         "@nestjs/typeorm": "^9.0.1",
+        "class-transformer": "^0.5.1",
         "class-validator": "^0.13.2",
         "connect-typeorm": "^2.0.0",
         "express-mysql-session": "^2.1.8",
@@ -3265,6 +3266,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
     },
     "node_modules/class-validator": {
       "version": "0.13.2",
@@ -11754,6 +11760,11 @@
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.2.2.tgz",
       "integrity": "sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==",
       "dev": true
+    },
+    "class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw=="
     },
     "class-validator": {
       "version": "0.13.2",

--- a/backend/package.json
+++ b/backend/package.json
@@ -27,6 +27,7 @@
     "@nestjs/passport": "^9.0.0",
     "@nestjs/platform-express": "^9.0.0",
     "@nestjs/typeorm": "^9.0.1",
+    "class-transformer": "^0.5.1",
     "class-validator": "^0.13.2",
     "connect-typeorm": "^2.0.0",
     "express-mysql-session": "^2.1.8",

--- a/backend/src/workspace/dto/workspace.dto.ts
+++ b/backend/src/workspace/dto/workspace.dto.ts
@@ -1,0 +1,23 @@
+import { IsDate, IsNumber, IsString, IsUUID } from 'class-validator';
+
+export class WorkspaceDto {
+  @IsUUID()
+  workspaceId?: string;
+
+  @IsNumber()
+  teamId?: number;
+
+  @IsString()
+  description?: string;
+
+  @IsString()
+  name?: string;
+
+  @IsDate()
+  registerDate: number;
+
+  @IsDate()
+  updateDate: number;
+
+  workspaceMember?: string[];
+}

--- a/backend/src/workspace/dto/workspaceCreateRequest.dto.ts
+++ b/backend/src/workspace/dto/workspaceCreateRequest.dto.ts
@@ -1,0 +1,16 @@
+import { IsNumber, IsString, IsOptional, IsEmpty } from 'class-validator';
+
+export class WorkspaceCreateRequestDto {
+  @IsNumber()
+  teamId: number;
+
+  @IsEmpty() // 현재는 외부 입력은 없으며, Session 정보를 그대로 활용한다.
+  ownerId: string;
+
+  @IsString()
+  name: string;
+
+  @IsString()
+  @IsOptional()
+  description: string;
+}

--- a/backend/src/workspace/dto/workspaceId.dto.ts
+++ b/backend/src/workspace/dto/workspaceId.dto.ts
@@ -1,0 +1,6 @@
+import { IsUUID } from 'class-validator';
+
+export class WorkspaceIdDto {
+  @IsUUID()
+  workspaceId: string;
+}

--- a/backend/src/workspace/dto/workspaceMetadata.dto.ts
+++ b/backend/src/workspace/dto/workspaceMetadata.dto.ts
@@ -1,0 +1,11 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class WorkspaceMetadataDto {
+  @IsString()
+  @IsOptional()
+  description: string;
+
+  @IsString()
+  @IsOptional()
+  name: string;
+}

--- a/backend/src/workspace/workspace.controller.ts
+++ b/backend/src/workspace/workspace.controller.ts
@@ -5,12 +5,15 @@ import {
   Param,
   Get,
   Post,
+  Delete,
   Body,
   UseGuards,
   ValidationPipe,
+  BadRequestException,
 } from '@nestjs/common';
 import { AuthorizationGuard } from 'src/auth/guard/session.guard';
 import { WorkspaceCreateRequestDto } from './dto/workspaceCreateRequest.dto';
+import { WorkspaceIdDto } from './dto/workspaceId.dto';
 import { Workspace } from './entity/workspace.entity';
 import { WorkspaceService } from './workspace.service';
 
@@ -50,5 +53,20 @@ export class WorkspaceController {
   @Get(':workspaceId')
   async getWorkspaceData(@Param('workspaceId') workspaceId: string) {
     return await this.workspaceService.getWorkspaceData(workspaceId);
+  }
+
+  @Post(':workspaceId/participant')
+  async addWorkspaceParticipant(
+    @Param(new ValidationPipe()) { workspaceId }: WorkspaceIdDto,
+    @Body('userId') userId: string,
+    @Body('role') role = 0,
+  ) {
+    if (!userId)
+      throw new BadRequestException('사용자를 지정해주시기 바랍니다.');
+    return await this.workspaceService.addUserIntoWorkspace(
+      userId,
+      workspaceId,
+      role,
+    );
   }
 }

--- a/backend/src/workspace/workspace.controller.ts
+++ b/backend/src/workspace/workspace.controller.ts
@@ -1,4 +1,54 @@
-import { Controller } from '@nestjs/common';
+/* eslint-disable @typescript-eslint/no-empty-function */
+import {
+  Controller,
+  Session,
+  Param,
+  Get,
+  Post,
+  Body,
+  UseGuards,
+  ValidationPipe,
+} from '@nestjs/common';
+import { AuthorizationGuard } from 'src/auth/guard/session.guard';
+import { WorkspaceCreateRequestDto } from './dto/workspaceCreateRequest.dto';
+import { Workspace } from './entity/workspace.entity';
+import { WorkspaceService } from './workspace.service';
 
 @Controller('workspace')
-export class WorkspaceController {}
+export class WorkspaceController {
+  constructor(private workspaceService: WorkspaceService) {}
+
+  @UseGuards(AuthorizationGuard)
+  @Post()
+  async createWorkspace(
+    @Body(new ValidationPipe()) body: WorkspaceCreateRequestDto,
+    @Session() session: Record<string, any>,
+  ): Promise<Workspace> {
+    body.ownerId = session.user.userId;
+    return this.workspaceService.createWorkspace(body);
+  }
+
+  // 유저가 접근 가능한 Workspace 조회 서비스 기능 테스트 목적 라우트입니다.
+  // @Get('/test/user')
+  // async getTest(@Session() session: Record<string, any>) {
+  //   return await this.workspaceService.getUserOwnWorkspaceList(
+  //     session.user.userId,
+  //   );
+  // }
+
+  // 팀 소유의 Workspace 조회 서비스 기능 테스트 목적 라우트입니다.
+  // @Get('/test/team/:teamId')
+  // async getTeamWorkspaceForTest(@Param('teamId') teamId: number) {
+  //   return await this.workspaceService.getTeamOwnWorkspaceList(teamId);
+  // }
+
+  @Get(':workspaceId/participant')
+  async getWorkspaceParticipantList(@Param('workspaceId') workspaceId: string) {
+    return await this.workspaceService.getWorkspaceParticipantList(workspaceId);
+  }
+
+  @Get(':workspaceId')
+  async getWorkspaceData(@Param('workspaceId') workspaceId: string) {
+    return await this.workspaceService.getWorkspaceData(workspaceId);
+  }
+}

--- a/backend/src/workspace/workspace.controller.ts
+++ b/backend/src/workspace/workspace.controller.ts
@@ -59,17 +59,27 @@ export class WorkspaceController {
   //   return await this.workspaceService.getTeamOwnWorkspaceList(teamId);
   // }
 
-  @Get(':workspaceId/participant')
+  @Get(':workspaceId/info/metadata')
+  async getWorkspaceMetadata(@Param('workspaceId') workspaceId: string) {
+    return await this.workspaceService.getWorkspaceMetadata(workspaceId);
+  }
+
+  @Get(':workspaceId/info/team')
+  async getWorkspaceOwnerTeam(@Param('workspaceId') workspaceId: string) {
+    return await this.workspaceService.getWorkspaceOwnerTeam(workspaceId);
+  }
+
+  @Get(':workspaceId/info/participant')
   async getWorkspaceParticipantList(@Param('workspaceId') workspaceId: string) {
     return await this.workspaceService.getWorkspaceParticipantList(workspaceId);
   }
 
-  @Get(':workspaceId')
+  @Get(':workspaceId/info')
   async getWorkspaceData(@Param('workspaceId') workspaceId: string) {
     return await this.workspaceService.getWorkspaceData(workspaceId);
   }
 
-  @Post(':workspaceId/participant')
+  @Post(':workspaceId/info/participant')
   async addWorkspaceParticipant(
     @Param(new ValidationPipe()) { workspaceId }: WorkspaceIdDto,
     @Body('userId') userId: string,
@@ -100,7 +110,7 @@ export class WorkspaceController {
   }
 
   @UseGuards(AuthorizationGuard)
-  @Patch(':workspaceId')
+  @Patch(':workspaceId/info/metadata')
   async updateWorkspaceMetadata(
     @Session() session: Record<string, any>,
     @Param(new ValidationPipe()) { workspaceId }: WorkspaceIdDto,
@@ -126,7 +136,7 @@ export class WorkspaceController {
   }
 
   @UseGuards(AuthorizationGuard)
-  @Patch(':workspaceId/participant')
+  @Patch(':workspaceId/info/participant')
   async updateUserAuthority(
     @Session() session: Record<string, any>,
     @Param(new ValidationPipe()) { workspaceId }: WorkspaceIdDto,

--- a/backend/src/workspace/workspace.controller.ts
+++ b/backend/src/workspace/workspace.controller.ts
@@ -60,22 +60,30 @@ export class WorkspaceController {
   // }
 
   @Get(':workspaceId/info/metadata')
-  async getWorkspaceMetadata(@Param('workspaceId') workspaceId: string) {
+  async getWorkspaceMetadata(
+    @Param(new ValidationPipe()) { workspaceId }: WorkspaceIdDto,
+  ) {
     return await this.workspaceService.getWorkspaceMetadata(workspaceId);
   }
 
   @Get(':workspaceId/info/team')
-  async getWorkspaceOwnerTeam(@Param('workspaceId') workspaceId: string) {
+  async getWorkspaceOwnerTeam(
+    @Param(new ValidationPipe()) { workspaceId }: WorkspaceIdDto,
+  ) {
     return await this.workspaceService.getWorkspaceOwnerTeam(workspaceId);
   }
 
   @Get(':workspaceId/info/participant')
-  async getWorkspaceParticipantList(@Param('workspaceId') workspaceId: string) {
+  async getWorkspaceParticipantList(
+    @Param(new ValidationPipe()) { workspaceId }: WorkspaceIdDto,
+  ) {
     return await this.workspaceService.getWorkspaceParticipantList(workspaceId);
   }
 
   @Get(':workspaceId/info')
-  async getWorkspaceData(@Param('workspaceId') workspaceId: string) {
+  async getWorkspaceData(
+    @Param(new ValidationPipe()) { workspaceId }: WorkspaceIdDto,
+  ) {
     return await this.workspaceService.getWorkspaceData(workspaceId);
   }
 

--- a/backend/src/workspace/workspace.module.ts
+++ b/backend/src/workspace/workspace.module.ts
@@ -1,8 +1,12 @@
 import { Module } from '@nestjs/common';
 import { WorkspaceService } from './workspace.service';
 import { WorkspaceController } from './workspace.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Workspace } from './entity/workspace.entity';
+import { WorkspaceMember } from './entity/workspace-member.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Workspace, WorkspaceMember])],
   providers: [WorkspaceService],
   controllers: [WorkspaceController],
 })

--- a/backend/src/workspace/workspace.service.ts
+++ b/backend/src/workspace/workspace.service.ts
@@ -117,6 +117,27 @@ export class WorkspaceService {
   }
 
   /**
+   * 특정 워크스페이스의 메타데이터를 불러옵니다.
+   * @param workspaceId 특정 워크스페이스에 대한 ID 값입니다.
+   * @returns 특정 워크스페이스의 메타데이터를 전달합니다.
+   */
+  async getWorkspaceMetadata(workspaceId: string): Promise<Workspace> {
+    return await this.workspaceRepository.findOne({
+      where: { workspaceId },
+    });
+  }
+
+  async getWorkspaceOwnerTeam(workspaceId: string): Promise<Team | null> {
+    return (
+      await this.workspaceRepository
+        .createQueryBuilder('w')
+        .where({ workspaceId })
+        .leftJoinAndSelect('w.team', 'team')
+        .getOne()
+    ).team;
+  }
+
+  /**
    * 특정 유저가 참여한 Workspace 목록을 가져옵니다.
    * @param userId 유저 ID 입니다.
    * @returns Workspace 목록을 가져옵니다.

--- a/backend/src/workspace/workspace.service.ts
+++ b/backend/src/workspace/workspace.service.ts
@@ -5,6 +5,7 @@ import { Team } from 'src/team/entity/team.entity';
 import { User } from 'src/user/entity/user.entity';
 import { Repository, DataSource } from 'typeorm';
 import { WorkspaceCreateRequestDto } from './dto/workspaceCreateRequest.dto';
+import { WorkspaceMetadataDto } from './dto/workspaceMetadata.dto';
 import { WorkspaceMember } from './entity/workspace-member.entity';
 import { Workspace } from './entity/workspace.entity';
 
@@ -194,6 +195,7 @@ export class WorkspaceService {
 
   /**
    * 워크스페이스를 삭제합니다.
+   *
    * ※주의※ 권한을 확인하지 않습니다. 삭제 전 권한을 확인해주시기 바랍니다.
    * @param workspaceId 삭제할 워크스페이스의 Id입니다.
    */
@@ -229,5 +231,28 @@ export class WorkspaceService {
       await queryRunner.release();
       throw e;
     }
+  }
+
+  /**
+   * 워크스페이스의 메타데이터를 변경합니다.
+   *
+   * ※주의※ 권한을 확인하지 않습니다. 사용 전에 권한을 확인해주시기 바랍니다.
+   * @param workspaceId 메타데이터를 수정할 워크스페이스의 ID입니다.
+   * @param newMetaData 변경할 메타데이터 객체입니다.
+   * @returns 변경 가능한 것이 존재할 경우 true를 반환합니다.
+   */
+  async updateWorkspaceMetadata(
+    workspaceId: string,
+    newMetaData: WorkspaceMetadataDto,
+  ): Promise<boolean> {
+    const workspaceFind = this.workspaceRepository.findOne({
+      where: { workspaceId },
+    });
+    if (!workspaceFind)
+      throw new BadRequestException('잘못된 워크스페이스 ID입니다.');
+    return (
+      (await this.workspaceRepository.update({ workspaceId }, newMetaData))
+        .affected > 0
+    );
   }
 }

--- a/backend/src/workspace/workspace.service.ts
+++ b/backend/src/workspace/workspace.service.ts
@@ -255,4 +255,29 @@ export class WorkspaceService {
         .affected > 0
     );
   }
+
+  /**
+   * 사용자의 워크스페이스에 대한 권한을 조정합니다.
+   *
+   * ※주의※ 권한을 확인하지 않습니다. 사용 전에 권한을 확인해주시기 바랍니다.
+   * @param workspaceId 권한 조정 대상인 워크스페이스 ID입니다.
+   * @param userId 권한 조정 대상인 사용자 ID 입니다.
+   * @param newRole 새로운 Role을 지정합니다.
+   */
+  async updateUesrAuthority(
+    workspaceId: string,
+    userId: string,
+    newRole: number,
+  ): Promise<boolean> {
+    return (
+      (
+        await this.workspaceMemberRepository
+          .createQueryBuilder()
+          .update({ role: newRole })
+          .where('workspace_id = :wid', { wid: workspaceId })
+          .andWhere('user_id = :uid', { uid: userId })
+          .execute()
+      ).affected > 0
+    );
+  }
 }

--- a/backend/src/workspace/workspace.service.ts
+++ b/backend/src/workspace/workspace.service.ts
@@ -251,8 +251,12 @@ export class WorkspaceService {
     if (!workspaceFind)
       throw new BadRequestException('잘못된 워크스페이스 ID입니다.');
     return (
-      (await this.workspaceRepository.update({ workspaceId }, newMetaData))
-        .affected > 0
+      (
+        await this.workspaceRepository.update(
+          { workspaceId },
+          { ...newMetaData, updateDate: () => 'CURRENT_TIMESTAMP' },
+        )
+      ).affected > 0
     );
   }
 

--- a/backend/src/workspace/workspace.service.ts
+++ b/backend/src/workspace/workspace.service.ts
@@ -1,4 +1,131 @@
-import { Injectable } from '@nestjs/common';
+/* eslint-disable @typescript-eslint/no-empty-function */
+import { Injectable, BadRequestException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Team } from 'src/team/entity/team.entity';
+import { User } from 'src/user/entity/user.entity';
+import { Repository, DataSource } from 'typeorm';
+import { WorkspaceCreateRequestDto } from './dto/workspaceCreateRequest.dto';
+import { WorkspaceMember } from './entity/workspace-member.entity';
+import { Workspace } from './entity/workspace.entity';
 
 @Injectable()
-export class WorkspaceService {}
+export class WorkspaceService {
+  constructor(
+    @InjectRepository(Workspace)
+    private workspaceRepository: Repository<Workspace>,
+    @InjectRepository(WorkspaceMember)
+    private workspaceMemberRepository: Repository<WorkspaceMember>,
+    private dataSource: DataSource,
+  ) {}
+
+  /**
+   * 워크스페이스를 생성합니다.
+   * @param param0 워크스페이스를 생성하는데 필요한 정보들입니다. (신규 워크스페이스를 소유할 팀/유저 ID와 워크스페이스 이름, 설명)
+   * @returns 생성한 워크스페이스의 정보를 반환합니다.
+   */
+  async createWorkspace({
+    teamId,
+    ownerId: userId,
+    name,
+    description,
+  }: WorkspaceCreateRequestDto): Promise<Workspace> {
+    const newWorkspace = new Workspace();
+    const workspaceMember = new WorkspaceMember();
+
+    const queryRunner = this.dataSource.createQueryRunner();
+    await queryRunner.startTransaction();
+
+    try {
+      const teamFind = await queryRunner.manager.findOne(Team, {
+        where: { teamId },
+      });
+      const userFind = await queryRunner.manager.findOne(User, {
+        where: { userId },
+      });
+      if (!teamFind || !userFind) {
+        await queryRunner.rollbackTransaction();
+        await queryRunner.release();
+        throw new BadRequestException('잘못된 사용자 ID 혹은 팀 ID 입니다.');
+      }
+
+      workspaceMember.role = 2;
+      workspaceMember.user = userFind;
+      workspaceMember.workspace = newWorkspace;
+
+      newWorkspace.team = teamFind;
+      newWorkspace.name = name;
+      newWorkspace.description = description ?? null;
+      newWorkspace.team = teamFind;
+
+      const ret = await queryRunner.manager.save(newWorkspace);
+      await queryRunner.manager.save(workspaceMember);
+
+      await queryRunner.commitTransaction();
+      await queryRunner.release();
+
+      return ret;
+    } catch (e) {
+      console.error(e);
+      await queryRunner.rollbackTransaction();
+      await queryRunner.release();
+      throw e; // 서버 오류니까 되던지기 한다.
+    }
+  }
+
+  /**
+   * 특정 워크스페이스에 대한 모든 정보를 가져옵니다. (소유 팀 + 워크스페이즈 참여자들 + 메타데이터)
+   * @param workspaceId 특정 워크스페이스에 대한 ID 값입니다.
+   * @return 특정 워크스페이스에 대한 모든 정보를 반환합니다.
+   */
+  async getWorkspaceData(workspaceId: string): Promise<Workspace> {
+    return await this.workspaceRepository
+      .createQueryBuilder('ws')
+      .where('ws.workspace_id = :id', { id: workspaceId })
+      .leftJoinAndSelect('ws.workspaceMember', 'wm')
+      .leftJoinAndSelect('wm.user', 'user')
+      .select()
+      .getOne();
+  }
+
+  /**
+   * 특정 워크스페이스에 한번이라도 참여한 사람들의 명단을 불러옵니다.
+   * @param workspaceId 특정 워크스페이스에 대한 ID 값입니다.
+   * @returns 특정 워크스페이스에 참여한 유저들의 명단입니다.
+   */
+  async getWorkspaceParticipantList(
+    workspaceId: string,
+  ): Promise<WorkspaceMember[]> {
+    return await this.workspaceMemberRepository
+      .createQueryBuilder('wm')
+      .where('wm.workspace_id = :id', { id: workspaceId })
+      .leftJoinAndSelect('wm.user', 'user')
+      .getMany();
+  }
+
+  /**
+   * 특정 유저가 참여한 Workspace 목록을 가져옵니다.
+   * @param userId 유저 ID 입니다.
+   * @returns Workspace 목록을 가져옵니다.
+   */
+  async getUserOwnWorkspaceList(userId: string): Promise<WorkspaceMember[]> {
+    return await this.workspaceMemberRepository
+      .createQueryBuilder('wm')
+      .where('wm.user_id = :id', { id: userId })
+      .leftJoinAndSelect('wm.workspace', 'ws')
+      .select(['wm.role', 'ws'])
+      .getMany();
+  }
+
+  /**
+   * 특정 팀이 소유한 Workspace 목록을 가져옵니다.
+   * @param teamId 팀 ID 입니다.
+   * @returns Workspace 목록을 가져옵니다.
+   */
+  async getTeamOwnWorkspaceList(teamId: number): Promise<Workspace[]> {
+    return await this.workspaceRepository
+      .createQueryBuilder('ws')
+      .leftJoin('ws.team', 'team')
+      .where('team.team_id = :id', { id: teamId })
+      .getMany();
+  }
+}


### PR DESCRIPTION
제목 : [feat] 워크스페이스 CRUD 구현 완료 closes #8 

본문:
### 이슈명
#8 BE - Workspace CRUD 구현
### 작업사항
- 워크스페이스 생성이 가능합니다. (`POST /workspace`, Body에 `{teamId: number, name?: string, description?: string}`이 필요합니다. 로그인하여야만 합니다.)
- 워크스페이스 정보 조회가 가능합니다. (`GET /workspace/:workspaceId/info`)
- 워크스페이스 참여 기록이 있는 사용자 목록을 조회할 수 있습니다. (`GET /workspace/:workspaceId/info/participant`)
- 워크스페이스 메타데이터를 조회할 수 있습니다. (`GET /workspace/:workspaceId/info/metadata`)
- 워크스페이스에 참여자를 초대할 수 있습니다. (초대 기능을 염두하여 구현하였습니다.) (`POST /workspace/:workspaceId/info/participant`, 보안은 염두에 두지 않아, 모든 이가 초기 권한 설정 및 초대할 수 있습니다.)
- 워크스페이스를 삭제할 수 있습니다. (`DELETE /workspace/:workspaceId`, 워크스페이스 소유 권한을 갖는 사용자만 삭제할 수 있습니다.)
- 워크스페이스 메타데이터(이름, 설명)를 갱신할 수 있습니다. (`PATCH /workspace/:workspaceId/info/metadata`, 워크스페이스 소유 권한을 갖는 사용자만 갱신할 수 있습니다. Body에 `{name?: string, description: string}`을 필요로 합니다.)
- 워크스페이스 참여자의 권한을 변경할 수 있습니다. (`PATCH /workspace/:workspaceId/info/participant`, 워크스페이스 소유 권한을 갖는 사용자만 갱신할 수 있습니다. Body에 `{userId: string, role: number}`를 필요로 합니다.)
