### PR TITLE
[fix] API 명세 작성 및 검토, Github Action 추가 closes #5, #48, #50

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,25 @@
+name: Try Deploy
+on:
+  push:
+    branches:
+      - dev
+  workflow_dispatch:
+
+jobs:
+  try-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: deploy
+        uses: appleboy/ssh-action@v0.1.5
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          port: ${{ secrets.SERVER_SSH_PORT }}
+          username: ${{ secrets.SERVER_USERNAME }}
+          password: ${{ secrets.SERVER_PASSWORD }}
+          script: |
+            export GIT_PROJECT_PATH=https://github.com/boostcampwm-2022/web22-BooCrum.git
+            export PROJECT_DIR_NAME=BooCrum
+            export BRANCH_NAME=dev
+            export FRONTEND_WORKING_DIR=frontend
+            export BACKEND_WORKING_DIR=backend
+            sh ~/scripts/deploy.sh

--- a/backend/README.md
+++ b/backend/README.md
@@ -14,6 +14,7 @@ GITHUB_CLIENT_SECRET=
 NODE_ENV=develop|production
 
 REDIRECT_AFTER_LOGIN=
+REDIRECT_FAIL_LOGIN=
 ```
 
 ## Description

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
-import { Controller, UseGuards, Get, Put, Req, Res, Session, UnauthorizedException } from '@nestjs/common';
+import { Controller, UseGuards, UseFilters, Get, Put, Req, Res, Session, UnauthorizedException } from '@nestjs/common';
 import { Request, Response } from 'express';
+import { UnAuthRedirectionFilter } from './filter/unauth-redirect.filter';
 import { GithubOAuthGuard } from './guard/github.guard';
 import { AuthorizationGuard, UnAuthorizationGuard } from './guard/session.guard';
 
@@ -10,11 +11,13 @@ export class AuthController {
 
   @UseGuards(GithubOAuthGuard)
   @UseGuards(UnAuthorizationGuard)
+  @UseFilters(UnAuthRedirectionFilter)
   @Get('/oauth/github')
   startGithubOAuthProcess() {}
 
   @UseGuards(GithubOAuthGuard)
   @UseGuards(UnAuthorizationGuard)
+  @UseFilters(UnAuthRedirectionFilter)
   @Get('/oauth/github_callback')
   handleGithubData(@Req() req: Request, @Session() session: Record<string, any>, @Res() res: Response): void {
     session.user = req.user;

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -1,19 +1,8 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
-import {
-  Controller,
-  UseGuards,
-  Get,
-  Put,
-  Req,
-  Res,
-  Session,
-} from '@nestjs/common';
+import { Controller, UseGuards, Get, Put, Req, Res, Session, UnauthorizedException } from '@nestjs/common';
 import { Request, Response } from 'express';
 import { GithubOAuthGuard } from './guard/github.guard';
-import {
-  AuthorizationGuard,
-  UnAuthorizationGuard,
-} from './guard/session.guard';
+import { AuthorizationGuard, UnAuthorizationGuard } from './guard/session.guard';
 
 @Controller('auth')
 export class AuthController {
@@ -27,11 +16,7 @@ export class AuthController {
   @UseGuards(GithubOAuthGuard)
   @UseGuards(UnAuthorizationGuard)
   @Get('/oauth/github_callback')
-  handleGithubData(
-    @Req() req: Request,
-    @Session() session: Record<string, any>,
-    @Res() res: Response,
-  ): void {
+  handleGithubData(@Req() req: Request, @Session() session: Record<string, any>, @Res() res: Response): void {
     session.user = req.user;
     res.redirect(process.env.REDIRECT_AFTER_LOGIN);
   }
@@ -40,5 +25,11 @@ export class AuthController {
   @Put('/logout')
   destroySession(@Req() req: Request): void {
     req.session.destroy(() => {});
+  }
+
+  @Get('/status')
+  checkLoginStatus(@Session() session: Record<string, any>, @Res() res: Response): void {
+    if (!session.user) throw new UnauthorizedException();
+    res.sendStatus(200);
   }
 }

--- a/backend/src/auth/filter/unauth-redirect.filter.ts
+++ b/backend/src/auth/filter/unauth-redirect.filter.ts
@@ -1,0 +1,13 @@
+import { ExceptionFilter, Catch, UnauthorizedException, ArgumentsHost, HttpException } from '@nestjs/common';
+import { Response } from 'express';
+
+@Catch(UnauthorizedException)
+export class UnAuthRedirectionFilter implements ExceptionFilter {
+  catch(exception: HttpException, host: ArgumentsHost) {
+    const context = host.switchToHttp();
+    const res = context.getResponse<Response>();
+    const statusCode = exception.getStatus();
+    console.log(process.env.REDIRECT_FAIL_LOGIN);
+    res.status(statusCode).redirect(process.env.REDIRECT_FAIL_LOGIN);
+  }
+}

--- a/backend/src/auth/strategy/github.strategy.ts
+++ b/backend/src/auth/strategy/github.strategy.ts
@@ -14,11 +14,7 @@ export class GithubStrategy extends PassportStrategy(Strategy, 'github') {
     super(options);
   }
 
-  async validate(
-    _accessToken: string,
-    _refreshToken: string,
-    profile: Profile,
-  ) {
+  async validate(_accessToken: string, _refreshToken: string, profile: Profile) {
     const userData: UserDto = {
       userId: profile.id,
       nickname: profile.username,

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -34,10 +34,7 @@ export class UserController {
   }
 
   @Get('/:userId/info/:type')
-  async getUserPartialData(
-    @Param('userId') userId: string,
-    @Param('type') type: string,
-  ): Promise<any> {
+  async getUserPartialData(@Param('userId') userId: string, @Param('type') type: string): Promise<any> {
     switch (type) {
       case 'profile':
         return await this.userService.getUserProfileData(userId);
@@ -46,9 +43,7 @@ export class UserController {
       case 'workspace':
         return await this.userService.getUserWorkspaceData(userId);
       default:
-        throw new BadRequestException(
-          `잘못된 유저 데이터 접근입니다. Param: ${type}`,
-        );
+        throw new BadRequestException(`잘못된 유저 데이터 접근입니다. Param: ${type}`);
     }
   }
 
@@ -60,10 +55,7 @@ export class UserController {
 
   @Get('/info/:type')
   @UseGuards(AuthorizationGuard)
-  async getMyPartialData(
-    @Param('type') type: string,
-    @Session() session: Record<string, any>,
-  ): Promise<any> {
+  async getMyPartialData(@Param('type') type: string, @Session() session: Record<string, any>): Promise<any> {
     const userId = session.user.userId;
     switch (type) {
       case 'profile':
@@ -73,40 +65,27 @@ export class UserController {
       case 'workspace':
         return await this.userService.getUserWorkspaceData(userId);
       default:
-        throw new BadRequestException(
-          `잘못된 유저 데이터 접근입니다. Param: ${type}`,
-        );
+        throw new BadRequestException(`잘못된 유저 데이터 접근입니다. Param: ${type}`);
     }
   }
 
   @Patch('/info')
   @UseGuards(AuthorizationGuard)
-  async changeUserData(
-    @Body() body: UserDto,
-    @Session() session: Record<string, any>,
-  ): Promise<UserDto> {
+  async changeUserData(@Body() body: UserDto, @Session() session: Record<string, any>): Promise<UserDto> {
     const { userId } = session.user;
     const ret: UserDto = await this.userService.changeUserData(userId, body);
     if (!ret) {
-      throw new BadRequestException(
-        '잘못되었거나 존재하지 않는 User ID 입니다.',
-      );
+      throw new BadRequestException('잘못되었거나 존재하지 않는 User ID 입니다.');
     }
     return ret;
   }
 
   @Delete()
   @UseGuards(AuthorizationGuard)
-  async deleteUser(
-    @Req() req: Request,
-    @Session() session: Record<string, any>,
-  ): Promise<void> {
+  async deleteUser(@Req() req: Request, @Session() session: Record<string, any>): Promise<void> {
     const { userId } = session.user;
     const ret = await this.userService.deleteUserData(userId);
-    if (!ret)
-      throw new ForbiddenException(
-        '잘못되었거나 존재하지 않는 User ID 입니다.',
-      );
+    if (!ret) throw new ForbiddenException('잘못되었거나 존재하지 않는 User ID 입니다.');
     req.session.destroy(() => {});
   }
 }

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -125,7 +125,7 @@ export class UserService {
   // 가져오는 정보는 "사용자 정보 + 소속 팀 및 권한 + 워크스페이스 및 권한" 입니다.
   async getUserData(userId: string): Promise<User> {
     // Join이 Row마다 이루어지는 것이 아니라, 그냥 배열에 Raw Object가 중첩되어 제공된다.
-    return await this.userRepository
+    const userData = await this.userRepository
       .createQueryBuilder('user')
       .where({ userId: userId })
       .leftJoinAndSelect('user.teamMember', 'teamMember')
@@ -151,10 +151,14 @@ export class UserService {
         'workspace.updateDate',
       ])
       .getOne();
+    if (!userData) throw new BadRequestException('유효하지 않은 사용자 ID입니다.');
+    return userData;
   }
 
   async getUserProfileData(userId: string): Promise<User> {
-    return await this.userRepository.findOne({ where: { userId } });
+    const userData = await this.userRepository.findOne({ where: { userId } });
+    if (!userData) throw new BadRequestException('유효하지 않은 사용자 ID입니다.');
+    return userData;
   }
 
   async getUserTeamData(userId: string): Promise<TeamMember[]> {
@@ -175,6 +179,7 @@ export class UserService {
         'team.registerDate',
       ])
       .getOne();
+    if (!userData) throw new BadRequestException('유효하지 않은 사용자 ID입니다.');
     return userData.teamMember;
   }
 
@@ -197,6 +202,7 @@ export class UserService {
         'workspace.updateDate',
       ])
       .getOne();
+    if (!userData) throw new BadRequestException('유효하지 않은 사용자 ID입니다.');
     return userData.workspaceMember;
   }
 }

--- a/backend/src/workspace/workspace.controller.ts
+++ b/backend/src/workspace/workspace.controller.ts
@@ -24,15 +24,8 @@ import { WorkspaceService } from './workspace.service';
 export class WorkspaceController {
   constructor(private workspaceService: WorkspaceService) {}
 
-  private async hasProperAuthority(
-    workspaceId: string,
-    userId: string,
-    authority: number,
-  ): Promise<boolean> {
-    return (
-      (await this.workspaceService.getAuthorityOfUser(workspaceId, userId)) >=
-      authority
-    );
+  private async hasProperAuthority(workspaceId: string, userId: string, authority: number): Promise<boolean> {
+    return (await this.workspaceService.getAuthorityOfUser(workspaceId, userId)) >= authority;
   }
 
   @UseGuards(AuthorizationGuard)
@@ -60,30 +53,22 @@ export class WorkspaceController {
   // }
 
   @Get(':workspaceId/info/metadata')
-  async getWorkspaceMetadata(
-    @Param(new ValidationPipe()) { workspaceId }: WorkspaceIdDto,
-  ) {
+  async getWorkspaceMetadata(@Param(new ValidationPipe()) { workspaceId }: WorkspaceIdDto) {
     return await this.workspaceService.getWorkspaceMetadata(workspaceId);
   }
 
   @Get(':workspaceId/info/team')
-  async getWorkspaceOwnerTeam(
-    @Param(new ValidationPipe()) { workspaceId }: WorkspaceIdDto,
-  ) {
+  async getWorkspaceOwnerTeam(@Param(new ValidationPipe()) { workspaceId }: WorkspaceIdDto) {
     return await this.workspaceService.getWorkspaceOwnerTeam(workspaceId);
   }
 
   @Get(':workspaceId/info/participant')
-  async getWorkspaceParticipantList(
-    @Param(new ValidationPipe()) { workspaceId }: WorkspaceIdDto,
-  ) {
+  async getWorkspaceParticipantList(@Param(new ValidationPipe()) { workspaceId }: WorkspaceIdDto) {
     return await this.workspaceService.getWorkspaceParticipantList(workspaceId);
   }
 
   @Get(':workspaceId/info')
-  async getWorkspaceData(
-    @Param(new ValidationPipe()) { workspaceId }: WorkspaceIdDto,
-  ) {
+  async getWorkspaceData(@Param(new ValidationPipe()) { workspaceId }: WorkspaceIdDto) {
     return await this.workspaceService.getWorkspaceData(workspaceId);
   }
 
@@ -93,13 +78,8 @@ export class WorkspaceController {
     @Body('userId') userId: string,
     @Body('role') role = 0,
   ) {
-    if (!userId)
-      throw new BadRequestException('사용자를 지정해주시기 바랍니다.');
-    return await this.workspaceService.addUserIntoWorkspace(
-      userId,
-      workspaceId,
-      role,
-    );
+    if (!userId) throw new BadRequestException('사용자를 지정해주시기 바랍니다.');
+    return await this.workspaceService.addUserIntoWorkspace(userId, workspaceId, role);
   }
 
   @UseGuards(AuthorizationGuard)
@@ -110,9 +90,7 @@ export class WorkspaceController {
   ) {
     const userId = session.user.userId;
     if (!(await this.hasProperAuthority(workspaceId, userId, 2))) {
-      throw new ForbiddenException(
-        '삭제하려는 워크스페이스에 대한 소유자 권한을 갖고 있지 않습니다.',
-      );
+      throw new ForbiddenException('삭제하려는 워크스페이스에 대한 소유자 권한을 갖고 있지 않습니다.');
     }
     this.workspaceService.deleteWorkspace(workspaceId);
   }
@@ -126,19 +104,12 @@ export class WorkspaceController {
   ): Promise<void> {
     const userId = session.user.userId;
     if (!(await this.hasProperAuthority(workspaceId, userId, 2))) {
-      throw new ForbiddenException(
-        '갱신하려는 워크스페이스에 대한 소유자 권한을 갖고 있지 않습니다.',
-      );
+      throw new ForbiddenException('갱신하려는 워크스페이스에 대한 소유자 권한을 갖고 있지 않습니다.');
     }
 
-    const res = this.workspaceService.updateWorkspaceMetadata(
-      workspaceId,
-      newMetadata,
-    );
+    const res = await this.workspaceService.updateWorkspaceMetadata(workspaceId, newMetadata);
     if (!res) {
-      throw new BadRequestException(
-        '갱신할 수 있는 워크스페이스가 존재하지 않습니다.',
-      );
+      throw new BadRequestException('갱신할 수 있는 워크스페이스가 존재하지 않습니다.');
     }
     return;
   }
@@ -153,19 +124,10 @@ export class WorkspaceController {
   ) {
     const userId = session.user.userId;
     if (!(await this.hasProperAuthority(workspaceId, userId, 2))) {
-      throw new ForbiddenException(
-        '워크스페이스에 대한 소유자 권한을 갖고 있지 않아 타인의 권한 변경이 불가능합니다.',
-      );
+      throw new ForbiddenException('워크스페이스에 대한 소유자 권한을 갖고 있지 않아 타인의 권한 변경이 불가능합니다.');
     }
-    const res = this.workspaceService.updateUesrAuthority(
-      workspaceId,
-      targetUserId,
-      role,
-    );
-    if (!res)
-      throw new BadRequestException(
-        '갱신할 수 있는 사용자가 워크스페이스 참여자 중에 존재하지 않습니다.',
-      );
+    const res = await this.workspaceService.updateUesrAuthority(workspaceId, targetUserId, role);
+    if (!res) throw new BadRequestException('갱신할 수 있는 사용자가 워크스페이스 참여자 중에 존재하지 않습니다.');
     return;
   }
 }

--- a/backend/src/workspace/workspace.service.ts
+++ b/backend/src/workspace/workspace.service.ts
@@ -166,6 +166,7 @@ export class WorkspaceService {
     const userFind = await this.workspaceMemberRepository
       .createQueryBuilder('wm')
       .where('wm.user_id = :id', { id: userId })
+      .andWhere('wm.workspace_id = :id', { id: workspaceId })
       .getOne();
     if (userFind) throw new BadRequestException('이미 존재하는 사용자입니다.');
 

--- a/backend/src/workspace/workspace.service.ts
+++ b/backend/src/workspace/workspace.service.ts
@@ -19,17 +19,16 @@ export class WorkspaceService {
     private dataSource: DataSource,
   ) {}
 
-  async getAuthorityOfUser(
-    workspaceId: string,
-    userId: string,
-  ): Promise<number> {
+  async getAuthorityOfUser(workspaceId: string, userId: string): Promise<number> {
     return (
-      await this.workspaceMemberRepository
-        .createQueryBuilder()
-        .where('user_id = :uid', { uid: userId })
-        .andWhere('workspace_id = :wid', { wid: workspaceId })
-        .getOne()
-    ).role;
+      (
+        await this.workspaceMemberRepository
+          .createQueryBuilder()
+          .where('user_id = :uid', { uid: userId })
+          .andWhere('workspace_id = :wid', { wid: workspaceId })
+          .getOne()
+      )?.role ?? 0
+    );
   }
 
   /**
@@ -37,12 +36,7 @@ export class WorkspaceService {
    * @param param0 워크스페이스를 생성하는데 필요한 정보들입니다. (신규 워크스페이스를 소유할 팀/유저 ID와 워크스페이스 이름, 설명)
    * @returns 생성한 워크스페이스의 정보를 반환합니다.
    */
-  async createWorkspace({
-    teamId,
-    ownerId: userId,
-    name,
-    description,
-  }: WorkspaceCreateRequestDto): Promise<Workspace> {
+  async createWorkspace({ teamId, ownerId: userId, name, description }: WorkspaceCreateRequestDto): Promise<Workspace> {
     const newWorkspace = new Workspace();
     const workspaceMember = new WorkspaceMember();
 
@@ -57,8 +51,6 @@ export class WorkspaceService {
         where: { userId },
       });
       if (!teamFind || !userFind) {
-        await queryRunner.rollbackTransaction();
-        await queryRunner.release();
         throw new BadRequestException('잘못된 사용자 ID 혹은 팀 ID 입니다.');
       }
 
@@ -96,6 +88,7 @@ export class WorkspaceService {
       .createQueryBuilder('ws')
       .where('ws.workspace_id = :id', { id: workspaceId })
       .leftJoinAndSelect('ws.workspaceMember', 'wm')
+      .leftJoinAndSelect('ws.team', 'team')
       .leftJoinAndSelect('wm.user', 'user')
       .select()
       .getOne();
@@ -106,9 +99,7 @@ export class WorkspaceService {
    * @param workspaceId 특정 워크스페이스에 대한 ID 값입니다.
    * @returns 특정 워크스페이스에 참여한 유저들의 명단입니다.
    */
-  async getWorkspaceParticipantList(
-    workspaceId: string,
-  ): Promise<WorkspaceMember[]> {
+  async getWorkspaceParticipantList(workspaceId: string): Promise<WorkspaceMember[]> {
     return await this.workspaceMemberRepository
       .createQueryBuilder('wm')
       .where('wm.workspace_id = :id', { id: workspaceId })
@@ -171,11 +162,7 @@ export class WorkspaceService {
    * @param role 유저가 해당 워크스페이스에 갖게될 권한입니다.
    * @returns 추가 결과를 반환합니다.
    */
-  async addUserIntoWorkspace(
-    userId: string,
-    workspaceId: string,
-    role = 0,
-  ): Promise<WorkspaceMember> {
+  async addUserIntoWorkspace(userId: string, workspaceId: string, role = 0): Promise<WorkspaceMember> {
     const userFind = await this.workspaceMemberRepository
       .createQueryBuilder('wm')
       .where('wm.user_id = :id', { id: userId })
@@ -196,9 +183,7 @@ export class WorkspaceService {
         where: { workspaceId },
       });
       if (!newMember.user || !newMember.workspace)
-        throw new BadRequestException(
-          '잘못된 사용자 Id 혹은 워크스페이스 Id입니다.',
-        );
+        throw new BadRequestException('잘못된 사용자 Id 혹은 워크스페이스 Id입니다.');
       newMember = await queryRunner.manager.save(newMember);
 
       await queryRunner.commitTransaction();
@@ -262,15 +247,11 @@ export class WorkspaceService {
    * @param newMetaData 변경할 메타데이터 객체입니다.
    * @returns 변경 가능한 것이 존재할 경우 true를 반환합니다.
    */
-  async updateWorkspaceMetadata(
-    workspaceId: string,
-    newMetaData: WorkspaceMetadataDto,
-  ): Promise<boolean> {
+  async updateWorkspaceMetadata(workspaceId: string, newMetaData: WorkspaceMetadataDto): Promise<boolean> {
     const workspaceFind = this.workspaceRepository.findOne({
       where: { workspaceId },
     });
-    if (!workspaceFind)
-      throw new BadRequestException('잘못된 워크스페이스 ID입니다.');
+    if (!workspaceFind) throw new BadRequestException('잘못된 워크스페이스 ID입니다.');
     return (
       (
         await this.workspaceRepository.update(
@@ -289,11 +270,7 @@ export class WorkspaceService {
    * @param userId 권한 조정 대상인 사용자 ID 입니다.
    * @param newRole 새로운 Role을 지정합니다.
    */
-  async updateUesrAuthority(
-    workspaceId: string,
-    userId: string,
-    newRole: number,
-  ): Promise<boolean> {
+  async updateUesrAuthority(workspaceId: string, userId: string, newRole: number): Promise<boolean> {
     return (
       (
         await this.workspaceMemberRepository


### PR DESCRIPTION
## 이슈명
- #5 
- #48 
- #50
## 작업 사항
1. 워크스페이스 생성 중에 잘못된 팀 ID / 유저 ID가 전달되면 트랜잭션 rollback을 2번하는 오류 수정
2. 특정 워크스페이스의 모든 정보 조회 시 팀 정보가 빠져있는 오류 수정
3. 특정 워크스페이스의 참여자 권한 변경 및 메타데이터 변경 시 await 키워드 누락으로 의도치 않은 응답을 뱉는 오류를 수정함.
4. 워크스페이스의 사용자 참여 여부 판정 시, Where 누락으로 잘못된 판정이 나오는 오류를 수정함.
5. 특정 유저 정보 조회 시, 존재하지 않는 사용자의 ID를 제공한 경우 오류를 반환하도록 로직을 수정함.

## 추가 작업 사항 (덤)
1. Github Action 자동 배포 추가 (`main` Branch로 직접 추가 안해도 되는지 테스트.)
2. 로그인 상태 확인 API 추가 (`GET /api/auth/status`)
3. OAuth 로그인 실패 시 리다이렉션을 수행할 수 있도록 수정 (`REDIRECT_FAIL_LOGIN` 환경변수 설정으로 조정 가능)

---

~뭔가 작업 사항이 늘어나는 것은 기분탓입니다~