### PR TITLE
[fix] workspace API 요구사항 반영 closes #60

### DIFF
--- a/backend/src/auth/auth.module.ts
+++ b/backend/src/auth/auth.module.ts
@@ -6,10 +6,14 @@ import { UserModule } from 'src/user/user.module';
 import { UserService } from 'src/user/user.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from 'src/user/entity/user.entity';
+import { TeamModule } from 'src/team/team.module';
+import { TeamService } from 'src/team/team.service';
+import { Team } from 'src/team/entity/team.entity';
+import { TeamMember } from 'src/team/entity/team-member.entity';
 
 @Module({
-  imports: [UserModule, TypeOrmModule.forFeature([User])],
+  imports: [UserModule, TeamModule, TypeOrmModule.forFeature([User, Team, TeamMember])],
   controllers: [AuthController],
-  providers: [AuthService, GithubStrategy, UserService],
+  providers: [AuthService, GithubStrategy, UserService, TeamService],
 })
 export class AuthModule {}

--- a/backend/src/team/team.service.ts
+++ b/backend/src/team/team.service.ts
@@ -175,4 +175,15 @@ export class TeamService {
   async findTeam(teamId: number): Promise<Team> {
     return await this.teamRepository.createQueryBuilder('team').where('team.team_id = :teamId', { teamId }).getOne();
   }
+
+  // user 개인 팀을 userId로 찾기
+  async findUserTeam(userId: string): Promise<Team> {
+    const ret = await this.teamMemberRepository
+      .createQueryBuilder('team_member')
+      .innerJoinAndSelect('team_member.team', 'team')
+      .where('team_member.user_id = :userId', { userId })
+      .andWhere('team.is_team = :isTeam', { isTeam: 0 })
+      .getOne();
+    return ret.team;
+  }
 }

--- a/backend/src/workspace/dto/workspaceCreateRequest.dto.ts
+++ b/backend/src/workspace/dto/workspaceCreateRequest.dto.ts
@@ -2,6 +2,7 @@ import { IsNumber, IsString, IsOptional, IsEmpty } from 'class-validator';
 
 export class WorkspaceCreateRequestDto {
   @IsNumber()
+  @IsOptional()
   teamId: number;
 
   @IsEmpty() // 현재는 외부 입력은 없으며, Session 정보를 그대로 활용한다.

--- a/backend/src/workspace/workspace.controller.ts
+++ b/backend/src/workspace/workspace.controller.ts
@@ -35,6 +35,7 @@ export class WorkspaceController {
     @Session() session: Record<string, any>,
   ): Promise<Workspace> {
     body.ownerId = session.user.userId;
+    if (!body.teamId) body.teamId = session.user.userTeamId;
     return this.workspaceService.createWorkspace(body);
   }
 
@@ -92,7 +93,7 @@ export class WorkspaceController {
     if (!(await this.hasProperAuthority(workspaceId, userId, 2))) {
       throw new ForbiddenException('삭제하려는 워크스페이스에 대한 소유자 권한을 갖고 있지 않습니다.');
     }
-    this.workspaceService.deleteWorkspace(workspaceId);
+    await this.workspaceService.deleteWorkspace(workspaceId);
   }
 
   @UseGuards(AuthorizationGuard)


### PR DESCRIPTION
## 이슈명
- #60 
## 작업 사항
- 워크스페이스 생성 시 teamId를 누락하면 개인이 생성한 워크스페이스로 간주함.
- session 정보에 개인을 뜻하는 팀 id를 추가로 기록하도록 변경함.
- teamService에 userId를 이용하여 개인을 뜻하는 팀을 반환하는 함수를 구현함. (`findUserTeam(userId: string)`)