### PR TITLE
[feat] Workspace 내부 Object CRUD API 구현 closes #9

### DIFF
--- a/backend/src/object-database/dto/create-object.dto.ts
+++ b/backend/src/object-database/dto/create-object.dto.ts
@@ -1,0 +1,25 @@
+import { IsNumber, IsOptional, IsString } from 'class-validator';
+
+export class CreateObjectDTO {
+  @IsString()
+  type: string;
+
+  @IsNumber()
+  xPos: number;
+
+  @IsNumber()
+  yPos: number;
+
+  @IsNumber()
+  width: number;
+
+  @IsNumber()
+  height: number;
+
+  @IsString()
+  color: string;
+
+  @IsString()
+  @IsOptional()
+  text: string;
+}

--- a/backend/src/object-database/dto/select-object.dto.ts
+++ b/backend/src/object-database/dto/select-object.dto.ts
@@ -1,0 +1,8 @@
+import { IsNumber, IsUUID } from 'class-validator';
+
+export class SelectObjectDTO {
+  @IsUUID()
+  workspaceId: string;
+
+  objectId: number;
+}

--- a/backend/src/object-database/object-database.controller.ts
+++ b/backend/src/object-database/object-database.controller.ts
@@ -2,10 +2,14 @@ import { Controller, Res, Get, Post, Delete, Param, ValidationPipe } from '@nest
 import { CreateTableRequestDto } from './dto/create-table-request.dto';
 import { ObjectDatabaseService } from './object-database.service';
 import { Response } from 'express';
+import { ObjectHandlerService } from './object-handler.service';
 
 @Controller('object-database')
 export class ObjectDatabaseController {
-  constructor(private objectDatabaseService: ObjectDatabaseService) {}
+  constructor(
+    private objectDatabaseService: ObjectDatabaseService,
+    private objectHandlerService: ObjectHandlerService,
+  ) {}
 
   @Post('/:workspaceId')
   async createObjectTable(@Param(new ValidationPipe()) { workspaceId }: CreateTableRequestDto) {
@@ -20,5 +24,10 @@ export class ObjectDatabaseController {
   @Get('/:workspaceId')
   async workspaceExist(@Param(new ValidationPipe()) { workspaceId }: CreateTableRequestDto, @Res() res: Response) {
     return res.sendStatus((await this.objectDatabaseService.isObjectTableExist(workspaceId)) ? 200 : 404);
+  }
+
+  @Get('/:workspaceId/objects')
+  async selectAllObjects(@Param(new ValidationPipe()) { workspaceId }: CreateTableRequestDto) {
+    return this.objectHandlerService.selectAllObjects(workspaceId);
   }
 }

--- a/backend/src/object-database/object-database.controller.ts
+++ b/backend/src/object-database/object-database.controller.ts
@@ -3,6 +3,7 @@ import { CreateTableRequestDto } from './dto/create-table-request.dto';
 import { ObjectDatabaseService } from './object-database.service';
 import { Response } from 'express';
 import { ObjectHandlerService } from './object-handler.service';
+import { SelectObjectDTO } from './dto/select-object.dto';
 
 @Controller('object-database')
 export class ObjectDatabaseController {
@@ -26,8 +27,13 @@ export class ObjectDatabaseController {
     return res.sendStatus((await this.objectDatabaseService.isObjectTableExist(workspaceId)) ? 200 : 404);
   }
 
-  @Get('/:workspaceId/objects')
+  @Get('/:workspaceId/object')
   async selectAllObjects(@Param(new ValidationPipe()) { workspaceId }: CreateTableRequestDto) {
     return this.objectHandlerService.selectAllObjects(workspaceId);
+  }
+
+  @Get('/:workspaceId/object/:objectId')
+  async selectOneObjects(@Param(new ValidationPipe()) { workspaceId, objectId }: SelectObjectDTO) {
+    return this.objectHandlerService.selectObjectById(workspaceId, objectId);
   }
 }

--- a/backend/src/object-database/object-database.controller.ts
+++ b/backend/src/object-database/object-database.controller.ts
@@ -1,9 +1,10 @@
-import { Controller, Res, Get, Post, Delete, Param, ValidationPipe } from '@nestjs/common';
+import { Controller, Res, Get, Post, Delete, Param, ValidationPipe, Body } from '@nestjs/common';
 import { CreateTableRequestDto } from './dto/create-table-request.dto';
 import { ObjectDatabaseService } from './object-database.service';
 import { Response } from 'express';
 import { ObjectHandlerService } from './object-handler.service';
 import { SelectObjectDTO } from './dto/select-object.dto';
+import { CreateObjectDTO } from './dto/create-object.dto';
 
 @Controller('object-database')
 export class ObjectDatabaseController {
@@ -35,5 +36,13 @@ export class ObjectDatabaseController {
   @Get('/:workspaceId/object/:objectId')
   async selectOneObjects(@Param(new ValidationPipe()) { workspaceId, objectId }: SelectObjectDTO) {
     return this.objectHandlerService.selectObjectById(workspaceId, objectId);
+  }
+
+  @Post('/:workspaceId/object')
+  async createObject(
+    @Param(new ValidationPipe()) { workspaceId }: CreateTableRequestDto,
+    @Body() createObjectDTO: CreateObjectDTO,
+  ) {
+    return this.objectHandlerService.createObject(workspaceId, createObjectDTO);
   }
 }

--- a/backend/src/object-database/object-database.controller.ts
+++ b/backend/src/object-database/object-database.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Res, Get, Post, Delete, Param, ValidationPipe, Body } from '@nestjs/common';
+import { Controller, Res, Get, Post, Delete, Param, ValidationPipe, Body, Patch } from '@nestjs/common';
 import { CreateTableRequestDto } from './dto/create-table-request.dto';
 import { ObjectDatabaseService } from './object-database.service';
 import { Response } from 'express';
@@ -41,8 +41,16 @@ export class ObjectDatabaseController {
   @Post('/:workspaceId/object')
   async createObject(
     @Param(new ValidationPipe()) { workspaceId }: CreateTableRequestDto,
-    @Body() createObjectDTO: CreateObjectDTO,
+    @Body(new ValidationPipe()) createObjectDTO: CreateObjectDTO,
   ) {
     return this.objectHandlerService.createObject(workspaceId, createObjectDTO);
+  }
+
+  @Patch('/:workspaceId/object/:objectId')
+  async updateObject(
+    @Param(new ValidationPipe()) { workspaceId, objectId }: SelectObjectDTO,
+    @Body() createObjectDTO: CreateObjectDTO,
+  ) {
+    return this.objectHandlerService.updateObject(workspaceId, objectId, createObjectDTO);
   }
 }

--- a/backend/src/object-database/object-database.controller.ts
+++ b/backend/src/object-database/object-database.controller.ts
@@ -30,12 +30,12 @@ export class ObjectDatabaseController {
 
   @Get('/:workspaceId/object')
   async selectAllObjects(@Param(new ValidationPipe()) { workspaceId }: CreateTableRequestDto) {
-    return this.objectHandlerService.selectAllObjects(workspaceId);
+    return await this.objectHandlerService.selectAllObjects(workspaceId);
   }
 
   @Get('/:workspaceId/object/:objectId')
   async selectOneObjects(@Param(new ValidationPipe()) { workspaceId, objectId }: SelectObjectDTO) {
-    return this.objectHandlerService.selectObjectById(workspaceId, objectId);
+    return await this.objectHandlerService.selectObjectById(workspaceId, objectId);
   }
 
   @Post('/:workspaceId/object')
@@ -43,7 +43,7 @@ export class ObjectDatabaseController {
     @Param(new ValidationPipe()) { workspaceId }: CreateTableRequestDto,
     @Body(new ValidationPipe()) createObjectDTO: CreateObjectDTO,
   ) {
-    return this.objectHandlerService.createObject(workspaceId, createObjectDTO);
+    return await this.objectHandlerService.createObject(workspaceId, createObjectDTO);
   }
 
   @Patch('/:workspaceId/object/:objectId')
@@ -51,6 +51,11 @@ export class ObjectDatabaseController {
     @Param(new ValidationPipe()) { workspaceId, objectId }: SelectObjectDTO,
     @Body() createObjectDTO: CreateObjectDTO,
   ) {
-    return this.objectHandlerService.updateObject(workspaceId, objectId, createObjectDTO);
+    return await this.objectHandlerService.updateObject(workspaceId, objectId, createObjectDTO);
+  }
+
+  @Delete('/:workspaceId/object/:objectId')
+  async deleteObject(@Param(new ValidationPipe()) { workspaceId, objectId }: SelectObjectDTO) {
+    return await this.objectHandlerService.deleteObject(workspaceId, objectId);
   }
 }

--- a/backend/src/object-database/object-database.module.ts
+++ b/backend/src/object-database/object-database.module.ts
@@ -6,10 +6,11 @@ import { WorkspaceService } from 'src/workspace/workspace.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Workspace } from 'src/workspace/entity/workspace.entity';
 import { WorkspaceMember } from 'src/workspace/entity/workspace-member.entity';
+import { ObjectHandlerService } from './object-handler.service';
 
 @Module({
   imports: [WorkspaceModule, TypeOrmModule.forFeature([Workspace, WorkspaceMember])],
   controllers: [ObjectDatabaseController],
-  providers: [ObjectDatabaseService, WorkspaceService],
+  providers: [ObjectDatabaseService, WorkspaceService, ObjectHandlerService],
 })
 export class ObjectDatabaseModule {}

--- a/backend/src/object-database/object-handler.service.spec.ts
+++ b/backend/src/object-database/object-handler.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ObjectHandlerService } from './object-handler.service';
+
+describe('ObjectHandlerService', () => {
+  let service: ObjectHandlerService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [ObjectHandlerService],
+    }).compile();
+
+    service = module.get<ObjectHandlerService>(ObjectHandlerService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/backend/src/object-database/object-handler.service.ts
+++ b/backend/src/object-database/object-handler.service.ts
@@ -24,4 +24,24 @@ export class ObjectHandlerService {
       await queryRunner.release();
     }
   }
+
+  async selectObjectById(workspaceId: string, objectId: number): Promise<RowDataPacket[] | undefined> {
+    const objectTable = this.objectDatabaseService.isObjectTableExist(workspaceId);
+    if (!objectTable) throw new BadRequestException('잘못된 워크스페이스 ID 입니다.');
+
+    const queryRunner = this.dataSource.createQueryRunner();
+    try {
+      await queryRunner.connect();
+      return (
+        await queryRunner.query(
+          `SELECT * FROM \`${OBJECT_DATABASE_NAME}\`.\`${workspaceId}\` WHERE object_id = ${objectId}`,
+        )
+      )[0];
+    } catch (error) {
+      console.log(error);
+      throw error;
+    } finally {
+      await queryRunner.release();
+    }
+  }
 }

--- a/backend/src/object-database/object-handler.service.ts
+++ b/backend/src/object-database/object-handler.service.ts
@@ -68,4 +68,36 @@ export class ObjectHandlerService {
       return ret;
     }
   }
+
+  async updateObject(workspaceId: string, objectId: number, createObjectDTO: CreateObjectDTO) {
+    const objectTable = this.objectDatabaseService.isObjectTableExist(workspaceId);
+    if (!objectTable) throw new BadRequestException('잘못된 워크스페이스 ID 입니다.');
+
+    const object = await this.selectObjectById(workspaceId, objectId);
+    if (!object) throw new BadRequestException('존재하지 않는 객체입니다.');
+
+    const queryRunner = this.dataSource.createQueryRunner();
+    let ret;
+
+    try {
+      await queryRunner.connect();
+      const { xPos, yPos, width, height, color, text } = createObjectDTO;
+      await queryRunner.query(
+        `UPDATE \`${OBJECT_DATABASE_NAME}\`.\`${workspaceId}\` 
+         SET x_pos = '${xPos}',
+         y_pos = '${yPos}',
+         width = '${width}',
+         height = '${height}',
+         color = '${color}',
+         text = '${text}'
+         WHERE object_id = '${objectId}'`,
+      );
+      ret = true;
+    } catch (error) {
+      ret = false;
+    } finally {
+      await queryRunner.release();
+      return ret;
+    }
+  }
 }

--- a/backend/src/object-database/object-handler.service.ts
+++ b/backend/src/object-database/object-handler.service.ts
@@ -100,4 +100,29 @@ export class ObjectHandlerService {
       return ret;
     }
   }
+
+  async deleteObject(workspaceId: string, objectId: number) {
+    const objectTable = this.objectDatabaseService.isObjectTableExist(workspaceId);
+    if (!objectTable) throw new BadRequestException('잘못된 워크스페이스 ID 입니다.');
+
+    const object = await this.selectObjectById(workspaceId, objectId);
+    if (!object) throw new BadRequestException('존재하지 않는 객체입니다.');
+
+    const queryRunner = this.dataSource.createQueryRunner();
+    let ret;
+
+    try {
+      await queryRunner.connect();
+      await queryRunner.query(
+        `DELETE FROM \`${OBJECT_DATABASE_NAME}\`.\`${workspaceId}\` 
+         WHERE object_id = '${objectId}'`,
+      );
+      ret = true;
+    } catch (error) {
+      ret = false;
+    } finally {
+      await queryRunner.release();
+      return ret;
+    }
+  }
 }

--- a/backend/src/object-database/object-handler.service.ts
+++ b/backend/src/object-database/object-handler.service.ts
@@ -3,6 +3,7 @@ import { RowDataPacket } from 'mysql2';
 import { WorkspaceService } from 'src/workspace/workspace.service';
 import { DataSource } from 'typeorm';
 import { OBJECT_DATABASE_NAME, OBJECT_TABLE_COLUMN_LIST } from './constant/object-database.constant';
+import { CreateObjectDTO } from './dto/create-object.dto';
 import { ObjectDatabaseService } from './object-database.service';
 
 @Injectable()
@@ -42,6 +43,29 @@ export class ObjectHandlerService {
       throw error;
     } finally {
       await queryRunner.release();
+    }
+  }
+
+  async createObject(workspaceId: string, createObjectDTO: CreateObjectDTO) {
+    const objectTable = this.objectDatabaseService.isObjectTableExist(workspaceId);
+    if (!objectTable) throw new BadRequestException('잘못된 워크스페이스 ID 입니다.');
+
+    const queryRunner = this.dataSource.createQueryRunner();
+    let ret;
+
+    try {
+      await queryRunner.connect();
+      const { type, xPos, yPos, width, height, color, text } = createObjectDTO;
+      await queryRunner.query(
+        `INSERT INTO \`${OBJECT_DATABASE_NAME}\`.\`${workspaceId}\` (type, x_pos, y_pos, width, height, color, text) 
+         VALUES ('${type}', '${xPos}', '${yPos}', '${width}', '${height}', '${color}', '${text}')`,
+      );
+      ret = true;
+    } catch (error) {
+      ret = false;
+    } finally {
+      await queryRunner.release();
+      return ret;
     }
   }
 }

--- a/backend/src/object-database/object-handler.service.ts
+++ b/backend/src/object-database/object-handler.service.ts
@@ -50,23 +50,11 @@ export class ObjectHandlerService {
     const objectTable = this.objectDatabaseService.isObjectTableExist(workspaceId);
     if (!objectTable) throw new BadRequestException('잘못된 워크스페이스 ID 입니다.');
 
-    const queryRunner = this.dataSource.createQueryRunner();
-    let ret;
+    const { type, xPos, yPos, width, height, color, text } = createObjectDTO;
+    const sql = `INSERT INTO \`${OBJECT_DATABASE_NAME}\`.\`${workspaceId}\` (type, x_pos, y_pos, width, height, color, text) 
+                 VALUES ('${type}', '${xPos}', '${yPos}', '${width}', '${height}', '${color}', '${text}')`;
 
-    try {
-      await queryRunner.connect();
-      const { type, xPos, yPos, width, height, color, text } = createObjectDTO;
-      await queryRunner.query(
-        `INSERT INTO \`${OBJECT_DATABASE_NAME}\`.\`${workspaceId}\` (type, x_pos, y_pos, width, height, color, text) 
-         VALUES ('${type}', '${xPos}', '${yPos}', '${width}', '${height}', '${color}', '${text}')`,
-      );
-      ret = true;
-    } catch (error) {
-      ret = false;
-    } finally {
-      await queryRunner.release();
-      return ret;
-    }
+    return await this.execute(sql);
   }
 
   async updateObject(workspaceId: string, objectId: number, createObjectDTO: CreateObjectDTO) {
@@ -76,29 +64,17 @@ export class ObjectHandlerService {
     const object = await this.selectObjectById(workspaceId, objectId);
     if (!object) throw new BadRequestException('존재하지 않는 객체입니다.');
 
-    const queryRunner = this.dataSource.createQueryRunner();
-    let ret;
+    const { xPos, yPos, width, height, color, text } = createObjectDTO;
+    const sql = `UPDATE \`${OBJECT_DATABASE_NAME}\`.\`${workspaceId}\` 
+                 SET x_pos = '${xPos}',
+                 y_pos = '${yPos}',
+                 width = '${width}',
+                 height = '${height}',
+                 color = '${color}',
+                 text = '${text}'
+                 WHERE object_id = '${objectId}'`;
 
-    try {
-      await queryRunner.connect();
-      const { xPos, yPos, width, height, color, text } = createObjectDTO;
-      await queryRunner.query(
-        `UPDATE \`${OBJECT_DATABASE_NAME}\`.\`${workspaceId}\` 
-         SET x_pos = '${xPos}',
-         y_pos = '${yPos}',
-         width = '${width}',
-         height = '${height}',
-         color = '${color}',
-         text = '${text}'
-         WHERE object_id = '${objectId}'`,
-      );
-      ret = true;
-    } catch (error) {
-      ret = false;
-    } finally {
-      await queryRunner.release();
-      return ret;
-    }
+    return await this.execute(sql);
   }
 
   async deleteObject(workspaceId: string, objectId: number) {
@@ -108,15 +84,19 @@ export class ObjectHandlerService {
     const object = await this.selectObjectById(workspaceId, objectId);
     if (!object) throw new BadRequestException('존재하지 않는 객체입니다.');
 
+    const sql = `DELETE FROM \`${OBJECT_DATABASE_NAME}\`.\`${workspaceId}\` 
+                 WHERE object_id = '${objectId}'`;
+
+    return await this.execute(sql);
+  }
+
+  async execute(sql: string): Promise<boolean> {
     const queryRunner = this.dataSource.createQueryRunner();
-    let ret;
+    let ret: boolean;
 
     try {
       await queryRunner.connect();
-      await queryRunner.query(
-        `DELETE FROM \`${OBJECT_DATABASE_NAME}\`.\`${workspaceId}\` 
-         WHERE object_id = '${objectId}'`,
-      );
+      await queryRunner.query(sql);
       ret = true;
     } catch (error) {
       ret = false;

--- a/backend/src/object-database/object-handler.service.ts
+++ b/backend/src/object-database/object-handler.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class ObjectHandlerService {}

--- a/backend/src/object-database/object-handler.service.ts
+++ b/backend/src/object-database/object-handler.service.ts
@@ -1,4 +1,27 @@
-import { Injectable } from '@nestjs/common';
+import { BadRequestException, Injectable } from '@nestjs/common';
+import { RowDataPacket } from 'mysql2';
+import { WorkspaceService } from 'src/workspace/workspace.service';
+import { DataSource } from 'typeorm';
+import { OBJECT_DATABASE_NAME, OBJECT_TABLE_COLUMN_LIST } from './constant/object-database.constant';
+import { ObjectDatabaseService } from './object-database.service';
 
 @Injectable()
-export class ObjectHandlerService {}
+export class ObjectHandlerService {
+  constructor(private dataSource: DataSource, private objectDatabaseService: ObjectDatabaseService) {}
+
+  async selectAllObjects(workspaceId: string): Promise<RowDataPacket[] | undefined> {
+    const objectTable = this.objectDatabaseService.isObjectTableExist(workspaceId);
+    if (!objectTable) throw new BadRequestException('잘못된 워크스페이스 ID 입니다.');
+
+    const queryRunner = this.dataSource.createQueryRunner();
+    try {
+      await queryRunner.connect();
+      return await queryRunner.query(`SELECT * FROM \`${OBJECT_DATABASE_NAME}\`.\`${workspaceId}\``);
+    } catch (error) {
+      console.log(error);
+      throw error;
+    } finally {
+      await queryRunner.release();
+    }
+  }
+}


### PR DESCRIPTION
### BE - Workspace 내부 Object 데이터 CRUD 구현

### 작업사항
- 객체 추가 API 구현
- 객체 삭제 API 구현
- 객체 수정 API 구현
- 객체 조회(전체, 1개) API 구현

### 추후 개선사항

- 현재 QueryRunner의 query() 메서드를 통해 SQL문을 직접 입력하여 로직을 구현하였으나, 이 방법이 아닌 방법을 찾아 리팩토링 하면 좋을 것 같음