### PR TITLE
[feat] Workspace 기능과 ObjectDataBase 기능 연결

### DIFF
--- a/backend/src/object-database/constant/object-database.constant.ts
+++ b/backend/src/object-database/constant/object-database.constant.ts
@@ -46,4 +46,10 @@ export const OBJECT_TABLE_COLUMN_LIST: TableColumnOptions[] = [
     type: 'TEXT',
     isNullable: true,
   },
+  {
+    name: 'creator',
+    type: 'varchar',
+    length: '50',
+    isNullable: false,
+  },
 ];

--- a/backend/src/object-database/object-database.controller.ts
+++ b/backend/src/object-database/object-database.controller.ts
@@ -14,8 +14,14 @@ export class ObjectDatabaseController {
   ) {}
 
   @Post('/:workspaceId')
-  async createObjectTable(@Param(new ValidationPipe()) { workspaceId }: CreateTableRequestDto) {
-    await this.objectDatabaseService.createObjectTable(workspaceId);
+  async createObjectTable(
+    @Param(new ValidationPipe()) { workspaceId }: CreateTableRequestDto,
+    @Body() { targetTable },
+    @Res() res: Response,
+  ) {
+    if (targetTable)
+      res.sendStatus((await this.objectDatabaseService.copyObjectTable(workspaceId, targetTable)) ? 201 : 400);
+    else await this.objectDatabaseService.createObjectTable(workspaceId);
   }
 
   @Delete('/:workspaceId')

--- a/backend/src/object-database/object-database.module.ts
+++ b/backend/src/object-database/object-database.module.ts
@@ -1,16 +1,13 @@
 import { Module } from '@nestjs/common';
 import { ObjectDatabaseService } from './object-database.service';
 import { ObjectDatabaseController } from './object-database.controller';
-import { WorkspaceModule } from 'src/workspace/workspace.module';
-import { WorkspaceService } from 'src/workspace/workspace.service';
-import { TypeOrmModule } from '@nestjs/typeorm';
-import { Workspace } from 'src/workspace/entity/workspace.entity';
-import { WorkspaceMember } from 'src/workspace/entity/workspace-member.entity';
 import { ObjectHandlerService } from './object-handler.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
 
 @Module({
-  imports: [WorkspaceModule, TypeOrmModule.forFeature([Workspace, WorkspaceMember])],
+  imports: [TypeOrmModule.forFeature()],
   controllers: [ObjectDatabaseController],
-  providers: [ObjectDatabaseService, WorkspaceService, ObjectHandlerService],
+  providers: [ObjectDatabaseService, ObjectHandlerService],
+  exports: [ObjectDatabaseService],
 })
 export class ObjectDatabaseModule {}

--- a/backend/src/object-database/object-database.service.ts
+++ b/backend/src/object-database/object-database.service.ts
@@ -105,7 +105,6 @@ export class ObjectDatabaseService {
         name: targetObjectTableName,
       }),
     );
-    console.log(isTableExist);
     if (!isTableExist) {
       await queryRunner.release();
       return false;

--- a/backend/src/object-database/object-database.service.ts
+++ b/backend/src/object-database/object-database.service.ts
@@ -44,11 +44,12 @@ export class ObjectDatabaseService {
    *
    * Object Table이 존재하지 않을 경우 무시됩니다.
    * @param workspaceId Object Table과 연결된 워크스페이스의 ID
+   * @param usedQueryRunner 해당 함수를 QueryRunner의 Transaction 도중에 사용하는 경우에 대응함.
    */
-  async deleteObjectTable(workspaceId: string): Promise<void> {
-    const queryRunner = this.dataSource.createQueryRunner();
+  async deleteObjectTable(workspaceId: string, usedQueryRunner?: QueryRunner): Promise<void> {
+    const queryRunner = usedQueryRunner ? usedQueryRunner : this.dataSource.createQueryRunner();
+    if (!usedQueryRunner) await queryRunner.connect();
     try {
-      await queryRunner.connect();
       await queryRunner.dropTable(
         new Table({
           database: OBJECT_DATABASE_NAME,
@@ -60,7 +61,7 @@ export class ObjectDatabaseService {
       console.log(error);
       throw error;
     } finally {
-      await queryRunner.release();
+      if (!usedQueryRunner) await queryRunner.release();
     }
   }
 

--- a/backend/src/object-database/object-handler.service.ts
+++ b/backend/src/object-database/object-handler.service.ts
@@ -1,6 +1,5 @@
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { RowDataPacket } from 'mysql2';
-import { WorkspaceService } from 'src/workspace/workspace.service';
 import { DataSource } from 'typeorm';
 import { OBJECT_DATABASE_NAME, OBJECT_TABLE_COLUMN_LIST } from './constant/object-database.constant';
 import { CreateObjectDTO } from './dto/create-object.dto';

--- a/backend/src/workspace/workspace.module.ts
+++ b/backend/src/workspace/workspace.module.ts
@@ -4,10 +4,12 @@ import { WorkspaceController } from './workspace.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Workspace } from './entity/workspace.entity';
 import { WorkspaceMember } from './entity/workspace-member.entity';
+import { ObjectDatabaseModule } from '../object-database/object-database.module';
+import { ObjectDatabaseService } from '../object-database/object-database.service';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Workspace, WorkspaceMember])],
-  providers: [WorkspaceService],
+  imports: [TypeOrmModule.forFeature([Workspace, WorkspaceMember]), ObjectDatabaseModule],
+  providers: [WorkspaceService, ObjectDatabaseService],
   controllers: [WorkspaceController],
 })
 export class WorkspaceModule {}

--- a/backend/src/workspace/workspace.service.ts
+++ b/backend/src/workspace/workspace.service.ts
@@ -8,6 +8,7 @@ import { WorkspaceCreateRequestDto } from './dto/workspaceCreateRequest.dto';
 import { WorkspaceMetadataDto } from './dto/workspaceMetadata.dto';
 import { WorkspaceMember } from './entity/workspace-member.entity';
 import { Workspace } from './entity/workspace.entity';
+import { ObjectDatabaseService } from 'src/object-database/object-database.service';
 
 @Injectable()
 export class WorkspaceService {
@@ -17,6 +18,7 @@ export class WorkspaceService {
     @InjectRepository(WorkspaceMember)
     private workspaceMemberRepository: Repository<WorkspaceMember>,
     private dataSource: DataSource,
+    private objectDatabaseService: ObjectDatabaseService,
   ) {}
 
   async getAuthorityOfUser(workspaceId: string, userId: string): Promise<number> {
@@ -65,6 +67,8 @@ export class WorkspaceService {
 
       const ret = await queryRunner.manager.save(newWorkspace);
       await queryRunner.manager.save(workspaceMember);
+
+      await this.objectDatabaseService.createObjectTable(ret.workspaceId, queryRunner);
 
       await queryRunner.commitTransaction();
       await queryRunner.release();

--- a/backend/src/workspace/workspace.service.ts
+++ b/backend/src/workspace/workspace.service.ts
@@ -229,7 +229,7 @@ export class WorkspaceService {
         .delete()
         .where('workspace_id = :id', { id: workspaceId })
         .execute();
-      // TODO: 워크스페이스 객체 테이블 DROP
+      await this.objectDatabaseService.deleteObjectTable(workspaceId, queryRunner);
       // 워크스페이스 메타데이터 제거
       await queryRunner.manager.delete(Workspace, { workspaceId });
 


### PR DESCRIPTION
## 관련 이슈
- #65 
- #8 
## 작업 사항
- Workspace 생성 시 Object Table도 생성되도록 변경
- Workspace 삭제 시 Object Table도 삭제되도록 변경
- 템플릿 생성에 대비하여 ObjectDatabaseService에 Object Table 복제 기능을 추가

## 주의 사항
- Workspace Module에서 ObjectDatabase Module을 참조하므로, 반대 방향으로 참조를 시도할 경우 순환참조가 발생하여 Nest에서 컴파일을 거부하니, 이 점 유의할 것. (즉, ObjectDatabase Module이 Workspace Module을 import 할 수 없다.)
- 순환 참조 문제로 인하여 간단한 Workspace 영역 메소드들은 직접 구현하게 됨.
- ObjectHandlerService에서 import하였으나 실질적으로 사용하지 않던 여러 Workspace 관련 요소들을 전부 걷어내었음.