### PR TITLE
[feat] 화이트보드 줌인 줌아웃 추가 closes #74

### DIFF
--- a/frontend/src/pages/workspace/header/index.style.tsx
+++ b/frontend/src/pages/workspace/header/index.style.tsx
@@ -1,10 +1,12 @@
 import styled from 'styled-components';
 
 export const Container = styled.div`
+	position: relative;
 	height: 56px;
+	z-index: 5;
 
 	border-bottom: 1px solid ${({ theme }) => theme.gray_1};
-
+	background-color: white;
 	display: flex;
 	align-items: center;
 

--- a/frontend/src/pages/workspace/index.tsx
+++ b/frontend/src/pages/workspace/index.tsx
@@ -10,7 +10,6 @@ function Workspace() {
 	return (
 		<>
 			<Layout name={name} />
-			<h1>Workspace</h1>
 			<WhiteboardCanvas></WhiteboardCanvas>
 		</>
 	);

--- a/frontend/src/pages/workspace/whiteboard-canvas/index.style.tsx
+++ b/frontend/src/pages/workspace/whiteboard-canvas/index.style.tsx
@@ -1,6 +1,8 @@
 import styled from 'styled-components';
 
-export const WhiteboardCanvasLayout = styled.canvas`
-	width: 1000px;
-	height: 1000px;
+export const WhiteboardCanvasLayout = styled.div`
+	position: fixed;
+	left: 0;
+	top: 0;
+	z-index: 0;
 `;

--- a/frontend/src/pages/workspace/whiteboard-canvas/index.tsx
+++ b/frontend/src/pages/workspace/whiteboard-canvas/index.tsx
@@ -1,9 +1,18 @@
 import { useEffect, useRef } from 'react';
 import { fabric } from 'fabric';
-import { drawingGird } from '@utils/fabric.utils';
+import { initGrid, initZoom, setZoomValue } from '@utils/fabric.utils';
+import { WhiteboardCanvasLayout } from './index.style';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { zoomState } from '@context/workspace';
 
 function WhiteboardCanvas() {
 	const canvas = useRef<fabric.Canvas | null>(null);
+	const [zoom, setZoom] = useRecoilState(zoomState);
+
+	useEffect(() => {
+		if (canvas.current) canvas.current.zoomToPoint({ x: window.innerWidth / 2, y: window.innerHeight / 2 }, zoom / 100);
+	}, [zoom]);
+
 	useEffect(() => {
 		canvas.current = initCanvas();
 		return () => {
@@ -16,8 +25,8 @@ function WhiteboardCanvas() {
 
 	const initCanvas = () => {
 		const grid = 50;
-		const canvasWidth = 2000;
-		const canvasHeight = 900;
+		const canvasWidth = window.innerWidth;
+		const canvasHeight = window.innerHeight;
 
 		const fabricCanvas = new fabric.Canvas('canvas', {
 			height: canvasHeight,
@@ -25,13 +34,8 @@ function WhiteboardCanvas() {
 			backgroundColor: '#f1f1f1',
 		});
 
-		drawingGird(fabricCanvas, canvasWidth, canvasHeight, grid);
-
-		// 이벤트 추가 예시
-		fabricCanvas.on('object:added', (e) => {
-			console.log(e);
-		});
-
+		initGrid(fabricCanvas, canvasWidth, canvasHeight, grid);
+		initZoom(fabricCanvas, setZoom);
 		return fabricCanvas;
 	};
 
@@ -57,9 +61,9 @@ function WhiteboardCanvas() {
 	};
 	return (
 		<>
-			<button onClick={addObj}>add</button>
-			<button onClick={clearObjects}>CLEAR</button>
-			<canvas id="canvas"></canvas>
+			<WhiteboardCanvasLayout>
+				<canvas id="canvas"></canvas>
+			</WhiteboardCanvasLayout>
 		</>
 	);
 }

--- a/frontend/src/pages/workspace/zoom-controller/index.tsx
+++ b/frontend/src/pages/workspace/zoom-controller/index.tsx
@@ -3,16 +3,15 @@ import zoomOut from '@assets/icon/zoom-out.svg';
 import zoomIn from '@assets/icon/zoom-in.svg';
 import { useRecoilState } from 'recoil';
 import { zoomState } from '@context/workspace';
-
 function ZoomController() {
 	const [zoom, setZoom] = useRecoilState(zoomState);
 
 	const handleZoomOut = () => {
-		setZoom((prevZoom) => (prevZoom - 10 > 0 ? prevZoom - 10 : prevZoom));
+		setZoom((prevZoom) => (prevZoom - 10 > 40 ? prevZoom - 10 : prevZoom));
 	};
 
 	const handleZoomIn = () => {
-		setZoom((prevZoom) => (prevZoom + 10 <= 100 ? prevZoom + 10 : prevZoom));
+		setZoom((prevZoom) => (prevZoom + 10 <= 200 ? prevZoom + 10 : prevZoom));
 	};
 
 	return (

--- a/frontend/src/utils/fabric.utils.ts
+++ b/frontend/src/utils/fabric.utils.ts
@@ -1,19 +1,40 @@
 import { fabric } from 'fabric';
+import { SetterOrUpdater } from 'recoil';
 
-export const drawingGird = (canvas: fabric.Canvas, width: number, height: number, gridSize: number) => {
-	for (let i = 0; i < width / gridSize; i++) {
-		const lineY = new fabric.Line([i * gridSize, 0, i * gridSize, height], {
+export const initGrid = (canvas: fabric.Canvas, width: number, height: number, gridSize: number) => {
+	for (let i = -width / gridSize; i <= (2 * width) / gridSize; i++) {
+		const lineY = new fabric.Line([i * gridSize, -height, i * gridSize, height * 2], {
 			type: 'line',
 			stroke: '#ccc',
 			selectable: false,
 		});
-		const lineX = new fabric.Line([0, i * gridSize, width, i * gridSize], {
-			type: 'line',
-			stroke: '#ccc',
-			selectable: false,
-		});
-		canvas.add(lineY, lineX);
-		canvas.sendToBack(lineX);
+
 		canvas.sendToBack(lineY);
 	}
+	for (let i = -height / gridSize; i <= (2 * height) / gridSize; i++) {
+		const lineX = new fabric.Line([-width, i * gridSize, width * 2, i * gridSize], {
+			type: 'line',
+			stroke: '#ccc',
+			selectable: false,
+		});
+
+		canvas.sendToBack(lineX);
+	}
+};
+
+export const initZoom = (canvas: fabric.Canvas, setZoom: SetterOrUpdater<number>) => {
+	canvas.on('mouse:wheel', function (opt) {
+		const delta = opt.e.deltaY;
+		let zoom = canvas.getZoom();
+		zoom += -delta / 1000;
+		if (zoom > 2) zoom = 2;
+		if (zoom < 0.5) zoom = 0.5;
+		setZoom(Math.round(zoom * 100));
+		opt.e.preventDefault();
+		opt.e.stopPropagation();
+	});
+};
+
+export const setZoomValue = (canvas: fabric.Canvas, zoom: number) => {
+	canvas.setZoom(zoom / 100);
 };


### PR DESCRIPTION
### 이슈명
- #74 
### 작업내용
- 화이트보드 크기 사용자 화면에 맞춤
- 화이트보드 Grid를 사용자 화면 크기의 3배의 크기로 그려줌
- 화이트보드 줌인 줌아웃은 현재 화면 중앙을 기준으로 실행 됨
- 화이트보드 줌 휠 이벤트랑 줌 컨트롤러 동기화

### 화면 캡처
![image](https://user-images.githubusercontent.com/72279836/203637446-e036ddd6-086d-4cfa-b68b-f2b3281b0e57.png)
![image](https://user-images.githubusercontent.com/72279836/203637496-f5f46027-837b-4080-a64d-106f3161906b.png)
