### PR TITLE
[feat] object 생성 구현 closes #105

### DIFF
--- a/frontend/patches/@types+fabric+4.5.12.patch
+++ b/frontend/patches/@types+fabric+4.5.12.patch
@@ -9,7 +9,7 @@ index 107db96..46a7ec2 100644
 +    isDragging?:boolean;
 +    lastPosX?:number;
 +    lastPosY?:number;
-+    moveMode?:boolean;
++    mode?:string;
      /**
       * When true, objects can be transformed by one side (unproportionally)
       * when dragged on the corners that normally would not do that.

--- a/frontend/src/pages/main/workspace-list/index.tsx
+++ b/frontend/src/pages/main/workspace-list/index.tsx
@@ -11,17 +11,13 @@ import { User } from '@api/user';
 function WorkspaceList({ title, hasOrder }: { title: string; hasOrder: boolean }) {
 	const orderType = useRecoilValue(workspaceOrderState);
 	const [workspaces, setWorkspaces] = useState<WorkspaceCardType[]>([]);
+
 	async function setWorkspaceList() {
 		const result = await User.getWorkspace();
 		const sortedWorkspace = sortWorkspace(result);
 		setWorkspaces(sortedWorkspace);
 	}
 	useEffect(() => {
-		// async function setWorkspaceList() {
-		// 	const result = await User.getWorkspace();
-		// 	const sortedWorkspace = sortWorkspace(result);
-		// 	setWorkspaces(sortedWorkspace);
-		// }
 		setWorkspaceList();
 	}, []);
 	useEffect(() => {

--- a/frontend/src/pages/workspace/whiteboard-canvas/index.tsx
+++ b/frontend/src/pages/workspace/whiteboard-canvas/index.tsx
@@ -1,21 +1,16 @@
 import { WhiteboardCanvasLayout } from './index.style';
-import { fabric } from 'fabric';
 import useCanvas from './useCanvas';
 import useSocket from './useSocket';
 import { useEffect, useState } from 'react';
 import ContextMenu from '@components/context-menu';
 import ObjectEditMenu from '../object-edit-menu';
 import { colorChips } from '@data/workspace-object-color';
-import { toolItems } from '@data/workspace-tool';
-import { useRecoilValue } from 'recoil';
-import { cursorState } from '@context/workspace';
 import useEditMenu from './useEditMenu';
 
 function WhiteboardCanvas() {
 	const { canvas } = useCanvas();
 	const { socket } = useSocket(canvas);
 	const { isOpen, menuRef, openMenu, menuPosition } = useEditMenu(canvas);
-	const cursor = useRecoilValue(cursorState);
 
 	useEffect(() => {
 		if (!canvas.current) return;
@@ -33,11 +28,11 @@ function WhiteboardCanvas() {
 		canvas.current.on('selection:created', (e) => {
 			// todo select 로직
 			console.log(e);
-			setEditMenu();
+			openMenu();
 		});
 
 		canvas.current.on('selection:updated', (e) => {
-			setEditMenu();
+			openMenu();
 		});
 
 		canvas.current.on('selection:cleared', (e) => {
@@ -55,37 +50,6 @@ function WhiteboardCanvas() {
 			console.log(e);
 		});
 	}, []);
-	useEffect(() => {
-		if (!canvas.current) return;
-
-		const fabricCanvas = canvas.current as fabric.Canvas;
-		if (cursor.type === toolItems.SECTION || cursor.type === toolItems.POST_IT) {
-			fabricCanvas.defaultCursor = 'context-menu';
-			fabricCanvas.selection = true;
-			if (cursor.type === toolItems.SECTION) fabricCanvas.mode = 'section';
-			else fabricCanvas.mode = 'postit';
-		} else if (cursor.type === toolItems.MOVE) {
-			fabricCanvas.defaultCursor = 'grab';
-			fabricCanvas.mode = 'move';
-			fabricCanvas.selection = false;
-		} else if (cursor.type === toolItems.SELECT) {
-			fabricCanvas.defaultCursor = 'default';
-			fabricCanvas.mode = 'select';
-			fabricCanvas.selection = true;
-		} else {
-			fabricCanvas.defaultCursor = 'default';
-			fabricCanvas.mode = 'draw';
-		}
-	}, [cursor]);
-
-	const setEditMenu = () => {
-		const currentObject = canvas.current?.getActiveObject();
-		const width = currentObject?.width || 0;
-		const top = currentObject?.top ? currentObject.top - 50 : 0;
-		const left = currentObject?.left ? currentObject.left + width / 2 : 0;
-
-		openMenu(left, top);
-	};
 
 	// object color 수정 초안
 	const [color, setColor] = useState(colorChips[0]); // 나중에 선택된 object의 color로 대체 예정

--- a/frontend/src/pages/workspace/whiteboard-canvas/index.tsx
+++ b/frontend/src/pages/workspace/whiteboard-canvas/index.tsx
@@ -58,15 +58,16 @@ function WhiteboardCanvas() {
 		const fabricCanvas = canvas.current as fabric.Canvas;
 		if (cursor.type === toolItems.SECTION || cursor.type === toolItems.POST_IT) {
 			fabricCanvas.defaultCursor = 'context-menu';
-			fabricCanvas.moveMode = false;
 			fabricCanvas.selection = true;
+			if (cursor.type === toolItems.SECTION) fabricCanvas.mode = 'section';
+			else fabricCanvas.mode = 'postit';
 		} else if (cursor.type === toolItems.MOVE) {
 			fabricCanvas.defaultCursor = 'grab';
-			fabricCanvas.moveMode = true;
+			fabricCanvas.mode = 'move';
 			fabricCanvas.selection = false;
-		} else {
+		} else if (cursor.type === toolItems.SELECT) {
 			fabricCanvas.defaultCursor = 'default';
-			fabricCanvas.moveMode = false;
+			fabricCanvas.mode = 'select';
 			fabricCanvas.selection = true;
 		}
 	}, [cursor]);

--- a/frontend/src/pages/workspace/whiteboard-canvas/index.tsx
+++ b/frontend/src/pages/workspace/whiteboard-canvas/index.tsx
@@ -56,17 +56,19 @@ function WhiteboardCanvas() {
 		if (!canvas.current) return;
 
 		const fabricCanvas = canvas.current as fabric.Canvas;
-		if (cursor.type === toolItems.MOVE) {
-			fabricCanvas.defaultCursor = 'grab';
-			fabricCanvas.selection = false;
-		} else if (cursor.type === toolItems.SECTION || cursor.type === toolItems.POST_IT) {
+		if (cursor.type === toolItems.SECTION || cursor.type === toolItems.POST_IT) {
 			fabricCanvas.defaultCursor = 'context-menu';
+			fabricCanvas.moveMode = false;
 			fabricCanvas.selection = true;
+		} else if (cursor.type === toolItems.MOVE) {
+			fabricCanvas.defaultCursor = 'grab';
+			fabricCanvas.moveMode = true;
+			fabricCanvas.selection = false;
 		} else {
 			fabricCanvas.defaultCursor = 'default';
+			fabricCanvas.moveMode = false;
 			fabricCanvas.selection = true;
 		}
-		// grab 상태에서 화면 움직이는 경우 grabbing으로 수정하는 부분 추가 필요
 	}, [cursor]);
 
 	// object color 수정 초안

--- a/frontend/src/pages/workspace/whiteboard-canvas/useCanvas.ts
+++ b/frontend/src/pages/workspace/whiteboard-canvas/useCanvas.ts
@@ -1,6 +1,6 @@
 import { useRef, useEffect } from 'react';
 import { fabric } from 'fabric';
-import { initGrid, initDragPanning, initWheelPanning, initZoom } from '@utils/fabric.utils';
+import { initObject, initDragPanning, initWheelPanning, initZoom } from '@utils/fabric.utils';
 import { toolItems } from '@data/workspace-tool';
 import { v4 } from 'uuid';
 import { useRecoilState, useRecoilValue } from 'recoil';
@@ -39,6 +39,7 @@ function useCanvas() {
 		initZoom(fabricCanvas, setZoom);
 		initDragPanning(fabricCanvas);
 		initWheelPanning(fabricCanvas);
+		initObject(fabricCanvas);
 
 		return fabricCanvas;
 	};

--- a/frontend/src/pages/workspace/whiteboard-canvas/useCanvas.ts
+++ b/frontend/src/pages/workspace/whiteboard-canvas/useCanvas.ts
@@ -1,8 +1,7 @@
 import { useRef, useEffect } from 'react';
 import { fabric } from 'fabric';
-import { initObject, initDragPanning, initWheelPanning, initZoom } from '@utils/fabric.utils';
+import { initObject, initDragPanning, initWheelPanning, initZoom, initGrid } from '@utils/fabric.utils';
 import { toolItems } from '@data/workspace-tool';
-import { v4 } from 'uuid';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { cursorState, zoomState } from '@context/workspace';
 
@@ -26,7 +25,31 @@ function useCanvas() {
 		};
 	}, []);
 
+	useEffect(() => {
+		if (!canvas.current) return;
+
+		const fabricCanvas = canvas.current as fabric.Canvas;
+		if (cursor.type === toolItems.SECTION || cursor.type === toolItems.POST_IT) {
+			fabricCanvas.defaultCursor = 'context-menu';
+			fabricCanvas.selection = true;
+			if (cursor.type === toolItems.SECTION) fabricCanvas.mode = 'section';
+			else fabricCanvas.mode = 'postit';
+		} else if (cursor.type === toolItems.MOVE) {
+			fabricCanvas.defaultCursor = 'grab';
+			fabricCanvas.mode = 'move';
+			fabricCanvas.selection = false;
+		} else if (cursor.type === toolItems.SELECT) {
+			fabricCanvas.defaultCursor = 'default';
+			fabricCanvas.mode = 'select';
+			fabricCanvas.selection = true;
+		} else {
+			fabricCanvas.defaultCursor = 'default';
+			fabricCanvas.mode = 'draw';
+		}
+	}, [cursor]);
+
 	const initCanvas = () => {
+		const grid = 50;
 		const canvasWidth = window.innerWidth;
 		const canvasHeight = window.innerHeight;
 
@@ -36,6 +59,7 @@ function useCanvas() {
 			backgroundColor: '#f1f1f1',
 		});
 
+		initGrid(fabricCanvas, canvasWidth, canvasHeight, grid);
 		initZoom(fabricCanvas, setZoom);
 		initDragPanning(fabricCanvas);
 		initWheelPanning(fabricCanvas);

--- a/frontend/src/pages/workspace/whiteboard-canvas/useCanvas.ts
+++ b/frontend/src/pages/workspace/whiteboard-canvas/useCanvas.ts
@@ -1,6 +1,6 @@
 import { useRef, useEffect } from 'react';
 import { fabric } from 'fabric';
-import { initObject, initDragPanning, initWheelPanning, initZoom, initGrid } from '@utils/fabric.utils';
+import { addObject, initDragPanning, initWheelPanning, initZoom, initGrid } from '@utils/fabric.utils';
 import { toolItems } from '@data/workspace-tool';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { cursorState, zoomState } from '@context/workspace';
@@ -63,7 +63,7 @@ function useCanvas() {
 		initZoom(fabricCanvas, setZoom);
 		initDragPanning(fabricCanvas);
 		initWheelPanning(fabricCanvas);
-		initObject(fabricCanvas);
+		addObject(fabricCanvas);
 
 		return fabricCanvas;
 	};

--- a/frontend/src/pages/workspace/whiteboard-canvas/useCanvas.ts
+++ b/frontend/src/pages/workspace/whiteboard-canvas/useCanvas.ts
@@ -1,26 +1,15 @@
 import { useRef, useEffect } from 'react';
 import { fabric } from 'fabric';
 import { initGrid, initDragPanning, initWheelPanning, initZoom } from '@utils/fabric.utils';
-import { useRecoilState, useRecoilValue } from 'recoil';
-import { cursorState, zoomState } from '@context/workspace';
 import { toolItems } from '@data/workspace-tool';
 import { v4 } from 'uuid';
+import { useRecoilState, useRecoilValue } from 'recoil';
+import { cursorState, zoomState } from '@context/workspace';
 
 function useCanvas() {
 	const canvas = useRef<fabric.Canvas | null>(null);
 	const [zoom, setZoom] = useRecoilState(zoomState);
 	const cursor = useRecoilValue(cursorState);
-	useEffect(() => {
-		if (cursor.type === toolItems.MOVE) {
-			if (canvas.current) {
-				canvas.current.moveMode = true;
-			}
-		} else {
-			if (canvas.current) {
-				canvas.current.moveMode = false;
-			}
-		}
-	}, [cursor]);
 
 	useEffect(() => {
 		if (canvas.current && zoom.event === 'control')
@@ -48,7 +37,6 @@ function useCanvas() {
 			backgroundColor: '#f1f1f1',
 		});
 
-		initGrid(fabricCanvas, canvasWidth, canvasHeight, grid);
 		initZoom(fabricCanvas, setZoom);
 		initDragPanning(fabricCanvas);
 		initWheelPanning(fabricCanvas);

--- a/frontend/src/pages/workspace/whiteboard-canvas/useCanvas.ts
+++ b/frontend/src/pages/workspace/whiteboard-canvas/useCanvas.ts
@@ -27,7 +27,6 @@ function useCanvas() {
 	}, []);
 
 	const initCanvas = () => {
-		const grid = 50;
 		const canvasWidth = window.innerWidth;
 		const canvasHeight = window.innerHeight;
 

--- a/frontend/src/pages/workspace/whiteboard-canvas/useEditMenu.ts
+++ b/frontend/src/pages/workspace/whiteboard-canvas/useEditMenu.ts
@@ -3,27 +3,50 @@ import { fabric } from 'fabric';
 
 function useEditMenu(canvas: React.MutableRefObject<fabric.Canvas | null>) {
 	const [isOpen, setIsOpen] = useState(false);
-	const menuRef = useRef<HTMLDivElement>(null);
 	const [menuPosition, setMenuPosition] = useState({ x: 0, y: 0 });
+	const menuRef = useRef<HTMLDivElement>(null);
 
 	useEffect(() => {
-		document.addEventListener('mousedown', handleOutsideClick);
+		if (!canvas.current) return;
+
+		canvas.current.on('mouse:down', handleOutsideClick);
+		canvas.current.on('object:moving', handleMenuPosition);
 
 		return () => {
-			document.removeEventListener('mousedown', handleOutsideClick);
+			canvas.current?.off('mouse:down', handleOutsideClick);
+			canvas.current?.off('object:moving', handleMenuPosition);
 		};
 	}, [isOpen]);
 
-	const openMenu = (x: number, y: number) => {
-		setIsOpen(!isOpen);
-		setMenuPosition({ x: x, y: y });
+	const openMenu = () => {
+		const currentObject = canvas.current?.getActiveObject();
+		const width = currentObject?.width || 0;
+		const top = currentObject?.top ? currentObject.top - 40 : 0;
+		const left = currentObject?.left ? currentObject.left + width / 2 - 30 : 0;
+
+		setIsOpen(true);
+		setMenuPosition({ x: left, y: top });
 	};
 
-	const handleOutsideClick = (e: Event) => {
+	const handleOutsideClick = (opt: fabric.IEvent) => {
 		if (!canvas.current) return;
 
-		if (isOpen && menuRef.current && !menuRef.current.contains(e.target as Node) && !canvas.current.getActiveObject())
+		if (
+			isOpen &&
+			menuRef.current &&
+			!menuRef.current.contains(opt.e.target as Node) &&
+			!canvas.current.getActiveObject()
+		)
 			setIsOpen(false);
+	};
+
+	const handleMenuPosition = (opt: fabric.IEvent) => {
+		if (!isOpen) return;
+
+		const width = opt.target?.width || 0;
+		const top = opt.target?.top ? opt.target.top - 40 : 0;
+		const left = opt.target?.left ? opt.target.left + width / 2 - 30 : 0;
+		setMenuPosition({ x: left, y: top });
 	};
 
 	return { isOpen, menuRef, openMenu, menuPosition };

--- a/frontend/src/pages/workspace/whiteboard-canvas/useEditMenu.ts
+++ b/frontend/src/pages/workspace/whiteboard-canvas/useEditMenu.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
+import { fabric } from 'fabric';
 
-function useContextMenu() {
+function useEditMenu(canvas: React.MutableRefObject<fabric.Canvas | null>) {
 	const [isOpen, setIsOpen] = useState(false);
 	const menuRef = useRef<HTMLDivElement>(null);
 	const [menuPosition, setMenuPosition] = useState({ x: 0, y: 0 });
@@ -13,21 +14,19 @@ function useContextMenu() {
 		};
 	}, [isOpen]);
 
-	const toggleOpen = (x: number, y: number) => {
+	const openMenu = (x: number, y: number) => {
 		setIsOpen(!isOpen);
 		setMenuPosition({ x: x, y: y });
 	};
 
-	const openContextMenu = () => {
-		setIsOpen(true);
-	};
-
 	const handleOutsideClick = (e: Event) => {
-		const current = menuRef.current;
-		if (isOpen && current && !current.contains(e.target as Node)) setIsOpen(false);
+		if (!canvas.current) return;
+
+		if (isOpen && menuRef.current && !menuRef.current.contains(e.target as Node) && !canvas.current.getActiveObject())
+			setIsOpen(false);
 	};
 
-	return { isOpen, menuRef, toggleOpen, menuPosition, openContextMenu };
+	return { isOpen, menuRef, openMenu, menuPosition };
 }
 
-export default useContextMenu;
+export default useEditMenu;

--- a/frontend/src/utils/fabric.utils.ts
+++ b/frontend/src/utils/fabric.utils.ts
@@ -1,7 +1,7 @@
 import { CanvasObject } from '@pages/workspace/whiteboard-canvas/index.types';
 import { fabric } from 'fabric';
 import { SetterOrUpdater } from 'recoil';
-import { v4 } from 'uuid';
+import { addPostIt, addSection } from './object.utils';
 
 <<<<<<< HEAD
 export const initGrid = (canvas: fabric.Canvas, width: number, height: number, gridSize: number) => {
@@ -53,11 +53,15 @@ export const initZoom = (
 export const initDragPanning = (canvas: fabric.Canvas) => {
 	canvas.on('mouse:down', function (opt) {
 		const evt = opt.e;
-		if (canvas.moveMode) {
+		if (canvas.mode === 'move') {
 			canvas.defaultCursor = 'grabbing';
 			canvas.isDragging = true;
 			canvas.lastPosX = evt.clientX;
 			canvas.lastPosY = evt.clientY;
+		} else if (canvas.mode === 'section' && !canvas.getActiveObject()) {
+			addSection(canvas, evt.clientX, evt.clientY);
+		} else if (canvas.mode === 'postit' && !canvas.getActiveObject()) {
+			addPostIt(canvas, evt.clientX, evt.clientY);
 		}
 	});
 	canvas.on('mouse:move', function (opt) {
@@ -77,7 +81,7 @@ export const initDragPanning = (canvas: fabric.Canvas) => {
 	canvas.on('mouse:up', function (opt) {
 		if (canvas.viewportTransform) canvas.setViewportTransform(canvas.viewportTransform);
 
-		if (canvas.moveMode) {
+		if (canvas.mode === 'move') {
 			canvas.defaultCursor = 'grab';
 			canvas.isDragging = false;
 		}

--- a/frontend/src/utils/fabric.utils.ts
+++ b/frontend/src/utils/fabric.utils.ts
@@ -3,6 +3,7 @@ import { fabric } from 'fabric';
 import { SetterOrUpdater } from 'recoil';
 import { v4 } from 'uuid';
 
+<<<<<<< HEAD
 export const initGrid = (canvas: fabric.Canvas, width: number, height: number, gridSize: number) => {
 	for (let i = -width / gridSize + 1; i <= (2 * width) / gridSize; i++) {
 		const lineY = new fabric.Line([i * gridSize, -height, i * gridSize, height * 2], {
@@ -26,6 +27,8 @@ export const initGrid = (canvas: fabric.Canvas, width: number, height: number, g
 	}
 };
 
+=======
+>>>>>>> 601262f (chore: fe - grabbing cursor 추가 #105)
 export const initZoom = (
 	canvas: fabric.Canvas,
 	setZoom: SetterOrUpdater<{
@@ -51,8 +54,8 @@ export const initDragPanning = (canvas: fabric.Canvas) => {
 	canvas.on('mouse:down', function (opt) {
 		const evt = opt.e;
 		if (canvas.moveMode) {
+			canvas.defaultCursor = 'grabbing';
 			canvas.isDragging = true;
-			canvas.selection = false;
 			canvas.lastPosX = evt.clientX;
 			canvas.lastPosY = evt.clientY;
 		}
@@ -72,11 +75,12 @@ export const initDragPanning = (canvas: fabric.Canvas) => {
 		}
 	});
 	canvas.on('mouse:up', function (opt) {
-		// on mouse up we want to recalculate new interaction
-		// for all objects, so we call setViewportTransform
 		if (canvas.viewportTransform) canvas.setViewportTransform(canvas.viewportTransform);
-		canvas.isDragging = false;
-		canvas.selection = true;
+
+		if (canvas.moveMode) {
+			canvas.defaultCursor = 'grab';
+			canvas.isDragging = false;
+		}
 	});
 };
 

--- a/frontend/src/utils/fabric.utils.ts
+++ b/frontend/src/utils/fabric.utils.ts
@@ -98,7 +98,7 @@ export const initWheelPanning = (canvas: fabric.Canvas) => {
 	});
 };
 
-export const initObject = (canvas: fabric.Canvas) => {
+export const addObject = (canvas: fabric.Canvas) => {
 	canvas.on('mouse:down', function (opt) {
 		const evt = opt.e;
 		if (canvas.mode === 'section' && !canvas.getActiveObject()) {

--- a/frontend/src/utils/fabric.utils.ts
+++ b/frontend/src/utils/fabric.utils.ts
@@ -1,9 +1,9 @@
 import { CanvasObject } from '@pages/workspace/whiteboard-canvas/index.types';
 import { fabric } from 'fabric';
 import { SetterOrUpdater } from 'recoil';
+import { v4 } from 'uuid';
 import { addPostIt, addSection } from './object.utils';
 
-<<<<<<< HEAD
 export const initGrid = (canvas: fabric.Canvas, width: number, height: number, gridSize: number) => {
 	for (let i = -width / gridSize + 1; i <= (2 * width) / gridSize; i++) {
 		const lineY = new fabric.Line([i * gridSize, -height, i * gridSize, height * 2], {
@@ -27,8 +27,6 @@ export const initGrid = (canvas: fabric.Canvas, width: number, height: number, g
 	}
 };
 
-=======
->>>>>>> 601262f (chore: fe - grabbing cursor 추가 #105)
 export const initZoom = (
 	canvas: fabric.Canvas,
 	setZoom: SetterOrUpdater<{
@@ -58,10 +56,6 @@ export const initDragPanning = (canvas: fabric.Canvas) => {
 			canvas.isDragging = true;
 			canvas.lastPosX = evt.clientX;
 			canvas.lastPosY = evt.clientY;
-		} else if (canvas.mode === 'section' && !canvas.getActiveObject()) {
-			addSection(canvas, evt.clientX, evt.clientY);
-		} else if (canvas.mode === 'postit' && !canvas.getActiveObject()) {
-			addPostIt(canvas, evt.clientX, evt.clientY);
 		}
 	});
 	canvas.on('mouse:move', function (opt) {
@@ -101,6 +95,17 @@ export const initWheelPanning = (canvas: fabric.Canvas) => {
 		}
 		canvas.requestRenderAll();
 		if (canvas.viewportTransform) canvas.setViewportTransform(canvas.viewportTransform);
+	});
+};
+
+export const initObject = (canvas: fabric.Canvas) => {
+	canvas.on('mouse:down', function (opt) {
+		const evt = opt.e;
+		if (canvas.mode === 'section' && !canvas.getActiveObject()) {
+			addSection(canvas, evt.clientX, evt.clientY);
+		} else if (canvas.mode === 'postit' && !canvas.getActiveObject()) {
+			addPostIt(canvas, evt.clientX, evt.clientY);
+		}
 	});
 };
 

--- a/frontend/src/utils/object.utils.ts
+++ b/frontend/src/utils/object.utils.ts
@@ -1,0 +1,31 @@
+import { colorChips } from '@data/workspace-object-color';
+import { fabric } from 'fabric';
+import { v4 } from 'uuid';
+
+export const addSection = (canvas: fabric.Canvas, x: number, y: number) => {
+	canvas.add(
+		new fabric.Rect({
+			objectId: v4(),
+			left: x,
+			top: y,
+			fill: colorChips[0],
+			width: 400,
+			height: 500,
+			objectCaching: false,
+		})
+	);
+};
+
+export const addPostIt = (canvas: fabric.Canvas, x: number, y: number) => {
+	canvas.add(
+		new fabric.Rect({
+			objectId: v4(),
+			left: x,
+			top: y,
+			fill: colorChips[0],
+			width: 300,
+			height: 200,
+			objectCaching: false,
+		})
+	);
+};

--- a/frontend/src/utils/object.utils.ts
+++ b/frontend/src/utils/object.utils.ts
@@ -29,3 +29,11 @@ export const addPostIt = (canvas: fabric.Canvas, x: number, y: number) => {
 		})
 	);
 };
+
+export const setEditMenu = (object: fabric.Object) => {
+	const width = object?.width || 0;
+	const top = object?.top ? object.top - 50 : 0;
+	const left = object?.left ? object.left + width / 2 : 0;
+
+	return [left, top];
+};


### PR DESCRIPTION
### 이슈명
- #105 

### 작업 사항
- 포스트잇 및 섹션 생성 구현

### 캡쳐 화면
![화면 기록 2022-11-25 20 26 25](https://user-images.githubusercontent.com/76840145/203976076-6e70291d-34a8-41a2-9f24-ca7bf36bc131.gif)

### 참고사항
- canvas에서 moveMode만 확인할 것이 아니라 모든 커서 상태를 확인하고 object를 추가(`addSection`, `addPostIt`)해야할 것 같아서 moveMode에서 mode로 속성을 수정했습니다.
- object가 이동할 때 object edit menu의 위치가 아직 안정적이지 않아 계속해서 수정해볼 예정입니다.