### PR TITLE
[refactor] - userProfile을 전역 상태로 관리

### DIFF
--- a/frontend/src/components/user-profile/index.tsx
+++ b/frontend/src/components/user-profile/index.tsx
@@ -5,20 +5,22 @@ import logoutIcon from '@assets/icon/logout.svg';
 import useContextMenu from '@hooks/useContextMenu';
 import useAuth from '@hooks/useAuth';
 import { User } from '@api/user';
+import { useRecoilValueLoadable } from 'recoil';
+import { userProfileState } from '@context/user';
 
 function UserProfile() {
+	const userProfileLoadable = useRecoilValueLoadable(userProfileState);
 	const [nickName, setNickName] = useState<string>('');
 	const { logout } = useAuth();
 
 	const { isOpen, menuRef, openContextMenu } = useContextMenu();
 
 	useEffect(() => {
-		async function setUserData() {
-			const { nickname } = await User.getProfile();
+		if (userProfileLoadable.state === 'hasValue') {
+			const { nickname } = userProfileLoadable.contents;
 			setNickName(nickname);
 		}
-		setUserData();
-	}, []);
+	}, [userProfileLoadable]);
 
 	return (
 		<Wrapper onClick={openContextMenu}>

--- a/frontend/src/context/auth.ts
+++ b/frontend/src/context/auth.ts
@@ -1,6 +1,0 @@
-import { atom } from 'recoil';
-
-export const authState = atom({
-	key: 'auth',
-	default: JSON.parse(localStorage.getItem('auth') || 'false'),
-});

--- a/frontend/src/context/user.ts
+++ b/frontend/src/context/user.ts
@@ -1,0 +1,18 @@
+import { ProfileData } from '@api/user.types';
+import { atom, selector } from 'recoil';
+import { User } from '@api/user';
+
+export const authState = atom({
+	key: 'auth',
+	default: JSON.parse(localStorage.getItem('auth') || 'false'),
+});
+
+export const userProfileState = selector({
+	key: 'useProfile',
+	get: async ({ get }): Promise<ProfileData> => {
+		const isAuth = get(authState);
+		if (!isAuth) return { userId: '', nickname: '', registerDate: '' };
+
+		return await User.getProfile();
+	},
+});

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { authState } from '@context/auth';
+import { authState } from '@context/user';
 import { useRecoilState } from 'recoil';
 import axios from 'axios';
 


### PR DESCRIPTION
### 이슈명

### 작업내용
- userProfile을 전역 상태로 리팩토링

### 공유 사항
- userProfile이 header에서도 쓰이고, 소켓에서도 자기가 보낸 이벤트를 필터링할 때 쓰일거라(그리고 더 쓰이지 않을까요?) selector로 비동기 전역 상태로 만들었습니다. 
- 부모 자식 관계가 아닌 2곳 이상에 쓰일 떄 전역 상태로 분리하고 있습니다