### PR TITLE
[feat] EditMenu 위치 설정 closes #123

### DIFF
--- a/frontend/src/pages/workspace/whiteboard-canvas/useEditMenu.ts
+++ b/frontend/src/pages/workspace/whiteboard-canvas/useEditMenu.ts
@@ -10,21 +10,24 @@ function useEditMenu(canvas: React.MutableRefObject<fabric.Canvas | null>) {
 		if (!canvas.current) return;
 
 		canvas.current.on('mouse:down', handleOutsideClick);
-		canvas.current.on('object:moving', handleMenuPosition);
+		canvas.current.on('object:modified', handleMenuPosition);
+		canvas.current.on('mouse:wheel', handleMenuPosition);
 
 		return () => {
 			canvas.current?.off('mouse:down', handleOutsideClick);
-			canvas.current?.off('object:moving', handleMenuPosition);
+			canvas.current?.off('object:modified', handleMenuPosition);
+			canvas.current?.off('mouse:wheel', handleMenuPosition);
 		};
 	}, [isOpen]);
 
 	const openMenu = () => {
 		const currentObject = canvas.current?.getActiveObject();
-		const width = currentObject?.width || 0;
-		const top = currentObject?.top ? currentObject.top - 40 : 0;
-		const left = currentObject?.left ? currentObject.left + width / 2 - 30 : 0;
+		const coord = currentObject?.getCoords();
+		const top = coord ? coord[0].y - 40 : 0;
+		const left = coord ? (coord[0].x + coord[1].x) / 2 - 30 : 0;
 
 		setIsOpen(true);
+		console.log(top, left);
 		setMenuPosition({ x: left, y: top });
 	};
 
@@ -42,10 +45,10 @@ function useEditMenu(canvas: React.MutableRefObject<fabric.Canvas | null>) {
 
 	const handleMenuPosition = (opt: fabric.IEvent) => {
 		if (!isOpen) return;
-
-		const width = opt.target?.width || 0;
-		const top = opt.target?.top ? opt.target.top - 40 : 0;
-		const left = opt.target?.left ? opt.target.left + width / 2 - 30 : 0;
+		const currentObject = canvas.current?.getActiveObject();
+		const coord = currentObject?.getCoords();
+		const top = coord ? coord[0].y - 40 : 0;
+		const left = coord ? (coord[0].x + coord[1].x) / 2 - 30 : 0;
 		setMenuPosition({ x: left, y: top });
 	};
 


### PR DESCRIPTION
### 이슈명
- #123 

### 작업내용
- EditMenu 위치 값 재설정
- Zoom 했을 때 메뉴 위치 변경
- Resize 했을 때 메뉴 위치 변경
- Object를 이동 시켰을 때 위치 변경

### 캡처본
![editmenu](https://user-images.githubusercontent.com/72279836/204213297-77859e58-bd84-4a79-a6c6-4922ae3cda05.gif)

### 추가사항
- getCoords() 는 모니터 화면기준에서 오브젝트의 좌표를 4개의점으로 알려줍니다.
- left, top 속성은 canvas 안의 좌표계를 기준의 위치를 나타냅니다.