### PR TITLE
[hotfix] 화이트보드 객체 업데이트 및 삭제 로직 오류 긴급 수정 #132

### DIFF
--- a/backend/src/migrations/1669621214094-change-object-columns.ts
+++ b/backend/src/migrations/1669621214094-change-object-columns.ts
@@ -2,14 +2,14 @@ import { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class changeObjectColumns1669621214094 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`ALTER TABLE \`workspace_object\` RENAME COLUMN \`x_pos\` TO \`left\`;`);
-    await queryRunner.query(`ALTER TABLE \`workspace_object\` RENAME COLUMN \`y_pos\` TO \`top\`;`);
+    await queryRunner.query(`ALTER TABLE \`workspace_object\` CHANGE \`x_pos\` \`left\` int;`);
+    await queryRunner.query(`ALTER TABLE \`workspace_object\` CHANGE \`y_pos\` \`top\` int;`);
     await queryRunner.query(`ALTER TABLE \`workspace_object\` ADD \`font_size\` int NOT NULL`);
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query(`ALTER TABLE \`workspace_object\` RENAME COLUMN \`left\` TO \`x_pos\`;`);
-    await queryRunner.query(`ALTER TABLE \`workspace_object\` RENAME COLUMN \`top\` TO \`y_pos\`;`);
+    await queryRunner.query(`ALTER TABLE \`workspace_object\` CHANGE \`left\` \`x_pos\` int;`);
+    await queryRunner.query(`ALTER TABLE \`workspace_object\` CHANGE \`top\` \`y_pos\` int;`);
     await queryRunner.query(`ALTER TABLE \`workspace_object\` DROP COLUMN \`font_size\``);
   }
 }

--- a/backend/src/object-database/object-handler.service.ts
+++ b/backend/src/object-database/object-handler.service.ts
@@ -96,7 +96,9 @@ export class ObjectHandlerService {
   async updateObject(workspaceId: string, updateObjectDTO: UpdateObjectDTO): Promise<boolean> {
     // selectObjectById에서 워크스페이스 및 오브젝트 존재 여부를 검증하므로, 여기서 검증은 생략한다.
     const object = await this.selectObjectById(workspaceId, updateObjectDTO.objectId);
-    const res = await this.objectRepository.update(object.objectId, updateObjectDTO);
+    const newData: WorkspaceObject = { ...object, ...updateObjectDTO };
+    delete (newData as any).workspaceId;
+    const res = await this.objectRepository.update(object.objectId, newData);
     return res.affected > 0;
   }
 

--- a/backend/src/socket/socket.gateway.ts
+++ b/backend/src/socket/socket.gateway.ts
@@ -47,7 +47,7 @@ export class SocketGateway implements OnGatewayInit, OnGatewayConnection, OnGate
       const role = !sessionUserData ? 0 : await this.dbAccessService.getOrCreateUserRoleAt(userId, workspaceId, 1); // 지금은 테스트 목적으로 초기권한 1로 잡음.
       const color = `#${Math.round(Math.random() * 0xffffff).toString(16)}`;
 
-      return new UserMapVO(userId, nickname, workspaceId, role, color, !!sessionUserData);
+      return new UserMapVO(userId, nickname, workspaceId, role, color, !sessionUserData);
     } catch (e) {
       this.logger.error(e);
       return null;
@@ -109,13 +109,11 @@ export class SocketGateway implements OnGatewayInit, OnGatewayConnection, OnGate
     //? workspaceId -> { idList: string[], userData: Map<string, UserData> } 형식으로?
     const members = Array.from(this.userMap.values())
       .filter((vo) => vo.workspaceId === workspaceId)
-      .map((vo) => new UserDAO(vo.userId, vo.nickname, vo.color));
+      .map((vo) => new UserDAO(vo.userId, vo.nickname, vo.color, vo.role));
     const objects = await this.objectHandlerService.selectAllObjects(workspaceId);
-    const userData = { ...userMapVO };
-    delete userData.workspaceId, userData.isGuest;
+    const userData = new UserDAO(userMapVO.userId, userMapVO.nickname, userMapVO.color, userMapVO.role);
 
     // 6. Socket 이벤트 Emit
-    //? 자신 포함이야... 자신 제외하고 보내야 하는거야...?
     client.emit('init', { members, objects, userData });
     client.nsp.emit('enter_user', userData);
   }
@@ -164,40 +162,55 @@ export class SocketGateway implements OnGatewayInit, OnGatewayConnection, OnGate
     if (userData.role < 1) throw new WsException('유효하지 않은 권한입니다.'); // 읽기 권한은 배제한다.
 
     // Optional 값들 중 값을 채워줘야 하는 것은 값을 넣어준다.
-    if (!objectData.text) objectData.text = '';
-    if (isNaN(+objectData.fontSize) || +objectData.fontSize < 0) objectData.fontSize = 16;
-    objectData.workspaceId = userData.workspaceId;
-    objectData.creator = socket.request.session.user.userId;
+    try {
+      if (!objectData.text) objectData.text = '';
+      if (isNaN(+objectData.fontSize) || +objectData.fontSize < 0) objectData.fontSize = 16;
+      objectData.workspaceId = userData.workspaceId;
+      objectData.creator = socket.request.session.user.userId;
 
-    // 생성을 시도하고, 성공하면 이를 전달한다.
-    const ret = await this.objectHandlerService.createObject(userData.workspaceId, objectData);
-    if (!ret) throw new WsException('생성 실패');
-    socket.nsp.emit('create_object', objectData);
+      // 생성을 시도하고, 성공하면 이를 전달한다.
+      const ret = await this.objectHandlerService.createObject(userData.workspaceId, objectData);
+      if (!ret) throw new WsException('생성 실패');
+      socket.nsp.emit('create_object', objectData);
+    } catch (e) {
+      this.logger.error(e);
+      throw new WsException(e.message);
+    }
   }
 
   @SubscribeMessage('update_object')
   async updateObject(@MessageBody() objectData: ObjectDTO, @ConnectedSocket() socket: Socket) {
-    const userData = this.userMap.get(socket.id);
-    if (userData.role < 1) throw new WsException('유효하지 않은 권한입니다.'); // 읽기 권한은 배제한다.
+    try {
+      const userData = this.userMap.get(socket.id);
+      if (userData.role < 1) throw new WsException('유효하지 않은 권한입니다.'); // 읽기 권한은 배제한다.
 
-    // 변경되어서는 안되는 값들은 미리 제거하거나 덮어버린다.
-    delete objectData.creator, objectData.objectId;
-    if (isNaN(+objectData.fontSize) || +objectData.fontSize < 0) delete objectData.fontSize;
-    objectData.workspaceId = userData.workspaceId;
+      // 변경되어서는 안되는 값들은 미리 제거하거나 덮어버린다.
+      delete objectData.creator, delete objectData.type;
+      if (isNaN(+objectData.fontSize) || +objectData.fontSize < 0) delete objectData.fontSize;
+      objectData.workspaceId = userData.workspaceId;
 
-    // 수정을 시도하고, 성공하면 이를 전달한다.
-    const ret = await this.objectHandlerService.updateObject(userData.workspaceId, objectData);
-    if (!ret) throw new WsException('수정 실패');
-    socket.nsp.emit('update_object', objectData);
+      // 수정을 시도하고, 성공하면 이를 전달한다.
+      const ret = await this.objectHandlerService.updateObject(userData.workspaceId, objectData);
+      if (!ret) throw new WsException('수정 실패');
+      socket.nsp.emit('update_object', objectData);
+    } catch (e) {
+      this.logger.error(e);
+      throw new WsException(e.message);
+    }
   }
 
   @SubscribeMessage('delete_object')
   async deleteObject(@MessageBody('objectId') objectId: string, @ConnectedSocket() socket: Socket) {
-    const userData = this.userMap.get(socket.id);
-    if (userData.role < 1) throw new WsException('유효하지 않은 권한입니다.'); // 읽기 권한은 배제한다.
+    try {
+      const userData = this.userMap.get(socket.id);
+      if (userData.role < 1) throw new WsException('유효하지 않은 권한입니다.'); // 읽기 권한은 배제한다.
 
-    const ret = await this.objectHandlerService.deleteObject(userData.workspaceId, objectId);
-    if (!ret) new WsException('삭제 실패');
-    socket.nsp.emit('delete_object', { objectId });
+      const ret = await this.objectHandlerService.deleteObject(userData.workspaceId, objectId);
+      if (!ret) new WsException('삭제 실패');
+      socket.nsp.emit('delete_object', { objectId });
+    } catch (e) {
+      this.logger.error(e);
+      throw new WsException(e.message);
+    }
   }
 }

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -74,7 +74,7 @@ export class UserService {
     }
 
     // 존재하면 Update를 진행한다.
-    delete newData.userId, newData.registerDate;
+    delete newData.userId, delete newData.registerDate;
     const res = await this.userRepository.update({ userId }, newData);
 
     if (res.affected !== 0)

--- a/backend/src/util/socket/user.dao.ts
+++ b/backend/src/util/socket/user.dao.ts
@@ -1,10 +1,11 @@
-import { IsString } from 'class-validator';
+import { IsNumber, IsString } from 'class-validator';
 
 export class UserDAO {
-  constructor(userId: string, nickname: string, color: string) {
+  constructor(userId: string, nickname: string, color: string, role: number) {
     this.userId = userId;
     this.nickname = nickname;
     this.color = color;
+    this.role = role;
   }
 
   @IsString()
@@ -15,4 +16,7 @@ export class UserDAO {
 
   @IsString()
   color: string;
+
+  @IsNumber()
+  role: number;
 }


### PR DESCRIPTION
## 관련 이슈
- #132
- #107

## 작업사항
- 소켓의 User 정보 중 isGuest 값이 실제와 반대로 기록되는 오류 수정
- 최초 연결 시 전달하는 유저 정보에서 Role이 누락되었던 문제 해결
- 최초 연결 시 전달할 데이터에서 제거되어야 했던 데이터들이 제거되지 않았던 문제 해결
- 갱신/삭제 로직에서 의도된 오류들 중 캐치되지 않아 500 오류를 반환하던 문제를 해결함
- 마이그레이션 코드 중 MySQL 버전 문제로 RENAME COLUMN 대신 CHANGE 구문으로 컬럼명 변경
- ObjectHandler에서 Object 정보 수정 시 제거되지 않은 정보(워크스페이스 ID)로 인하여 update가 실패하던 오류 수정