### PR TITLE
[fix] Section 제목 최대 길이 설정 closes #138

### DIFF
--- a/backend/src/socket/socket.gateway.ts
+++ b/backend/src/socket/socket.gateway.ts
@@ -170,6 +170,9 @@ export class SocketGateway implements OnGatewayInit, OnGatewayConnection, OnGate
       objectData.workspaceId = userData.workspaceId;
       objectData.creator = socket.request.session.user.userId;
 
+      // section의 제목의 최대 길이는 50자
+      if (objectData.type === 'section' && objectData.text.length > 50) throw new WsException('섹션 제목 길이 초과');
+
       // 생성을 시도하고, 성공하면 이를 전달한다.
       const ret = await this.objectHandlerService.createObject(userData.workspaceId, objectData);
       if (!ret) throw new WsException('생성 실패');

--- a/backend/src/socket/socket.gateway.ts
+++ b/backend/src/socket/socket.gateway.ts
@@ -191,6 +191,9 @@ export class SocketGateway implements OnGatewayInit, OnGatewayConnection, OnGate
       if (isNaN(+objectData.fontSize) || +objectData.fontSize < 0) delete objectData.fontSize;
       objectData.workspaceId = userData.workspaceId;
 
+      // section의 제목의 최대 길이는 50자
+      if (objectData.type === 'section' && objectData.text.length > 50) throw new WsException('섹션 제목 길이 초과');
+
       // 수정을 시도하고, 성공하면 이를 전달한다.
       const ret = await this.objectHandlerService.updateObject(userData.workspaceId, objectData);
       if (!ret) throw new WsException('수정 실패');


### PR DESCRIPTION
### BE - Section 제목 길이 설정

### 작업사항

- Socket의 `update_object`와 `create_object` 이벤트를 통해 섹션을 다룰 때 섹션 제목의 글자 수가 50자 이상일 경우 예외 처리