### PR TITLE
[feat] addSection 구현 closes #126

### DIFF
--- a/frontend/src/pages/workspace/whiteboard-canvas/useCanvas.ts
+++ b/frontend/src/pages/workspace/whiteboard-canvas/useCanvas.ts
@@ -1,6 +1,14 @@
 import { useRef, useEffect } from 'react';
 import { fabric } from 'fabric';
-import { addObject, initDragPanning, initWheelPanning, initZoom, initGrid, deleteObject } from '@utils/fabric.utils';
+import {
+	addObject,
+	initDragPanning,
+	initWheelPanning,
+	initZoom,
+	initGrid,
+	deleteObject,
+	setObjectIndexLeveling,
+} from '@utils/fabric.utils';
 import { toolItems } from '@data/workspace-tool';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { cursorState, zoomState } from '@context/workspace';
@@ -67,6 +75,7 @@ function useCanvas() {
 		initWheelPanning(fabricCanvas);
 		addObject(fabricCanvas);
 		deleteObject(fabricCanvas);
+		setObjectIndexLeveling(fabricCanvas);
 
 		return fabricCanvas;
 	};

--- a/frontend/src/pages/workspace/whiteboard-canvas/useCanvas.ts
+++ b/frontend/src/pages/workspace/whiteboard-canvas/useCanvas.ts
@@ -73,7 +73,7 @@ function useCanvas() {
 		initZoom(fabricCanvas, setZoom);
 		initDragPanning(fabricCanvas);
 		initWheelPanning(fabricCanvas);
-		addObject(fabricCanvas);
+		addObject(fabricCanvas, 'NAME');
 		deleteObject(fabricCanvas);
 		setObjectIndexLeveling(fabricCanvas);
 

--- a/frontend/src/types/fabric-options.d.ts
+++ b/frontend/src/types/fabric-options.d.ts
@@ -1,0 +1,53 @@
+interface TitleBackgroundOptions {
+	objectId: string;
+	left: number;
+	top: number;
+	color: string;
+}
+
+interface SectionOption {
+	objectId: string;
+	left: number;
+	top: number;
+	sectionTitle: fabric.IText;
+	titleBackground: fabric.Rect;
+	backgroundRect: fabric.Rect;
+}
+
+interface SectionTitleOptions {
+	objectId: string;
+	text?: string;
+	left: number;
+	top: number;
+}
+
+interface PostItOptions {
+	objectId: string;
+	left: number;
+	top: number;
+	textBox: fabric.Textbox;
+	nameLabel: fabric.Text;
+	backgroundRect: fabric.Rect;
+}
+
+interface TextBoxOptions {
+	objectId: string;
+	left: number;
+	top: number;
+	fontSize: number;
+	text?: string;
+}
+
+interface RectOptions {
+	objectId: string;
+	left: number;
+	top: number;
+	color: string;
+}
+
+interface NameLabelOptions {
+	objectId: string;
+	text: string;
+	left: number;
+	top: number;
+}

--- a/frontend/src/utils/fabric.utils.ts
+++ b/frontend/src/utils/fabric.utils.ts
@@ -117,7 +117,7 @@ export const deleteObject = (canvas: fabric.Canvas) => {
 	const objectDeleteHandler = (e: KeyboardEvent) => {
 		if (e.key === 'Backspace') {
 			canvas.getActiveObjects().forEach((obj) => {
-				if (obj instanceof fabric.Textbox) {
+				if (obj instanceof fabric.Textbox || obj instanceof fabric.IText) {
 					return;
 				}
 				canvas.remove(obj);

--- a/frontend/src/utils/fabric.utils.ts
+++ b/frontend/src/utils/fabric.utils.ts
@@ -101,7 +101,7 @@ export const initWheelPanning = (canvas: fabric.Canvas) => {
 	});
 };
 
-export const addObject = (canvas: fabric.Canvas) => {
+export const addObject = (canvas: fabric.Canvas, creator: string) => {
 	//todo 색 정보 받아와야함
 	canvas.on('mouse:down', function (opt) {
 		const evt = opt.e;
@@ -112,7 +112,7 @@ export const addObject = (canvas: fabric.Canvas) => {
 		if (canvas.mode === 'section' && !canvas.getActiveObject()) {
 			addSection(canvas, x, y, colorChips[8]);
 		} else if (canvas.mode === 'postit' && !canvas.getActiveObject()) {
-			addPostIt(canvas, x, y, 40, colorChips[0]);
+			addPostIt(canvas, x, y, 40, colorChips[0], creator);
 		}
 	});
 };

--- a/frontend/src/utils/fabric.utils.ts
+++ b/frontend/src/utils/fabric.utils.ts
@@ -1,4 +1,5 @@
 import { colorChips } from '@data/workspace-object-color';
+import { ObjectType } from '@pages/workspace/whiteboard-canvas/types';
 import { fabric } from 'fabric';
 import { SetterOrUpdater } from 'recoil';
 import { v4 } from 'uuid';
@@ -140,8 +141,7 @@ export const deleteObject = (canvas: fabric.Canvas) => {
 
 export const setObjectIndexLeveling = (canvas: fabric.Canvas) => {
 	canvas.on('object:added', (e) => {
-		const postits = canvas._objects.filter((obj) => obj.type === 'postit');
-		console.log(postits);
+		const postits = canvas._objects.filter((obj) => obj.type === ObjectType.postit);
 
 		postits.forEach((obj) => {
 			obj.bringToFront();

--- a/frontend/src/utils/fabric.utils.ts
+++ b/frontend/src/utils/fabric.utils.ts
@@ -1,3 +1,4 @@
+import { colorChips } from '@data/workspace-object-color';
 import { fabric } from 'fabric';
 import { SetterOrUpdater } from 'recoil';
 import { v4 } from 'uuid';
@@ -98,6 +99,7 @@ export const initWheelPanning = (canvas: fabric.Canvas) => {
 };
 
 export const addObject = (canvas: fabric.Canvas) => {
+	//todo 색 정보 받아와야함
 	canvas.on('mouse:down', function (opt) {
 		const evt = opt.e;
 		const vpt = canvas.viewportTransform;
@@ -105,10 +107,9 @@ export const addObject = (canvas: fabric.Canvas) => {
 		const x = (evt.clientX - vpt[4]) / vpt[3];
 		const y = (evt.clientY - vpt[5]) / vpt[3];
 		if (canvas.mode === 'section' && !canvas.getActiveObject()) {
-			addSection(canvas, x, y);
+			addSection(canvas, x, y, colorChips[8]);
 		} else if (canvas.mode === 'postit' && !canvas.getActiveObject()) {
-			//todo 색 정보 받아와야함
-			addPostIt(canvas, x, y, 40, 'pink');
+			addPostIt(canvas, x, y, 40, colorChips[0]);
 		}
 	});
 };
@@ -132,5 +133,16 @@ export const deleteObject = (canvas: fabric.Canvas) => {
 	// object 선택 해제시 이벤트 삭제
 	canvas.on('selection:cleared', () => {
 		document.removeEventListener('keydown', objectDeleteHandler);
+	});
+};
+
+export const setObjectIndexLeveling = (canvas: fabric.Canvas) => {
+	canvas.on('object:added', (e) => {
+		const postits = canvas._objects.filter((obj) => obj.type === 'postit');
+		console.log(postits);
+
+		postits.forEach((obj) => {
+			obj.bringToFront();
+		});
 	});
 };

--- a/frontend/src/utils/object-from-server.ts
+++ b/frontend/src/utils/object-from-server.ts
@@ -11,7 +11,7 @@ import {
 	createRect,
 	createTextBox,
 	setLimitHeightEvent,
-	setPostItEditEvent,
+	setObjectEditEvent,
 	setPreventResizeEvent,
 } from './object.utils';
 
@@ -47,8 +47,8 @@ export const createPostitFromServer = (canvas: fabric.Canvas, newObject: ObjectD
 		isSocketObject: true,
 	});
 	setLimitHeightEvent(canvas, textBox, backgroundRect);
-	setPostItEditEvent(canvas, postit, textBox);
-	setPreventResizeEvent(canvas);
+	setObjectEditEvent(canvas, postit, textBox);
+	setPreventResizeEvent(postit.objectId, canvas, backgroundRect);
 	canvas.add(postit);
 };
 

--- a/frontend/src/utils/object-from-server.ts
+++ b/frontend/src/utils/object-from-server.ts
@@ -25,9 +25,9 @@ export const createObjectFromServer = (canvas: fabric.Canvas, newObject: ObjectD
 export const createPostitFromServer = (canvas: fabric.Canvas, newObject: ObjectDataFromServer) => {
 	const { objectId, left, top, fontSize, color, text, width, height } = newObject;
 	if (!left || !top || !fontSize || !color || !text || !width || !height) return;
-	const nameLabel = createNameLabel(objectId, 'NAME', left, top);
-	const textBox = createTextBox(objectId, left, top, fontSize, text);
-	const backgroundRect = createRect(objectId, left, top, color);
+	const nameLabel = createNameLabel({ objectId, text: 'NAME', left, top });
+	const textBox = createTextBox({ objectId, left, top, fontSize, text });
+	const backgroundRect = createRect({ objectId, left, top, color });
 	backgroundRect.set({
 		width,
 		height,
@@ -42,7 +42,7 @@ export const createPostitFromServer = (canvas: fabric.Canvas, newObject: ObjectD
 		isSocketObject: true,
 	});
 
-	const postit = createPostIt(objectId, left, top, textBox, nameLabel, backgroundRect);
+	const postit = createPostIt({ objectId, left, top, textBox, nameLabel, backgroundRect });
 	postit.set({
 		isSocketObject: true,
 	});

--- a/frontend/src/utils/object.utils.ts
+++ b/frontend/src/utils/object.utils.ts
@@ -2,18 +2,12 @@ import { colorChips } from '@data/workspace-object-color';
 import { fabric } from 'fabric';
 import { v4 } from 'uuid';
 
-export const addSection = (canvas: fabric.Canvas, x: number, y: number) => {
-	canvas.add(
-		new fabric.Rect({
-			objectId: v4(),
-			left: x,
-			top: y,
-			fill: colorChips[0],
-			width: 400,
-			height: 500,
-			objectCaching: false,
-		})
-	);
+export const setEditMenu = (object: fabric.Object) => {
+	const width = object?.width || 0;
+	const top = object?.top ? object.top - 50 : 0;
+	const left = object?.left ? object.left + width / 2 : 0;
+
+	return [left, top];
 };
 
 const createNameLabel = (id: string, text: string, x: number, y: number) => {
@@ -138,18 +132,25 @@ const setPostItEditEvent = (canvas: fabric.Canvas, postit: fabric.Group, textBox
 	});
 };
 
-const setPreventResizeEvent = (canvas: fabric.Canvas) => {
+const setPreventResizeEvent = (canvas: fabric.Canvas, backgroundRect: fabric.Rect) => {
 	canvas.on('object:scaling', (e) => {
 		if (!(e.target instanceof fabric.Group)) return;
 		const objs = e.target._objects;
+		const rect = backgroundRect;
 
 		objs.forEach((obj) => {
 			if (obj instanceof fabric.Textbox || obj instanceof fabric.Text) {
 				const group = e.target;
-				const width = (group?.getScaledWidth() || 1) - 20 * (group?.scaleX || 1);
+				const width = (group?.getScaledWidth() || 0) - 20 * (group?.scaleX || 1);
+
 				const scaleX = 1 / (group?.scaleX || 1);
 				const scaleY = 1 / (group?.scaleY || 1);
-				obj.set({ scaleX: scaleX, scaleY: scaleY, width: width });
+				obj.set({
+					scaleX: scaleX,
+					scaleY: scaleY,
+					width: width,
+					left: (rect?.get('left') || 0) + 10,
+				});
 				obj.fire('changed');
 			}
 		});
@@ -165,15 +166,23 @@ export const addPostIt = (canvas: fabric.Canvas, x: number, y: number, fontSize:
 
 	setLimitHeightEvent(canvas, textBox, backgroundRect);
 	setPostItEditEvent(canvas, postit, textBox);
-	setPreventResizeEvent(canvas);
+	setPreventResizeEvent(canvas, backgroundRect);
 
 	canvas.add(postit);
 };
 
-export const setEditMenu = (object: fabric.Object) => {
-	const width = object?.width || 0;
-	const top = object?.top ? object.top - 50 : 0;
-	const left = object?.left ? object.left + width / 2 : 0;
+// Section
 
-	return [left, top];
+export const addSection = (canvas: fabric.Canvas, x: number, y: number) => {
+	canvas.add(
+		new fabric.Rect({
+			objectId: v4(),
+			left: x,
+			top: y,
+			fill: colorChips[0],
+			width: 400,
+			height: 500,
+			objectCaching: false,
+		})
+	);
 };

--- a/frontend/src/utils/object.utils.ts
+++ b/frontend/src/utils/object.utils.ts
@@ -10,14 +10,14 @@ export const setEditMenu = (object: fabric.Object) => {
 	return [left, top];
 };
 
-export const createNameLabel = (id: string, text: string, x: number, y: number) => {
-	const defaultLeft = x + 10;
-	const defaultTop = y + 275;
+export const createNameLabel = (options: NameLabelOptions) => {
+	const defaultLeft = options.left + 10;
+	const defaultTop = options.top + 275;
 	const defaultFontSize = 15;
 
-	const nameLabelText = new fabric.Text(text, {
+	const nameLabelText = new fabric.Text(options.text || '', {
 		type: ObjectType.nameText,
-		objectId: id,
+		objectId: options.objectId,
 		top: defaultTop,
 		left: defaultLeft,
 		fontSize: defaultFontSize,
@@ -28,16 +28,16 @@ export const createNameLabel = (id: string, text: string, x: number, y: number) 
 	return nameLabelText;
 };
 
-export const createRect = (id: string, x: number, y: number, fill: string) => {
+export const createRect = (options: RectOptions) => {
 	const defaultWidth = 300;
 	const defaultHeight = 300;
 
 	const rect = new fabric.Rect({
-		objectId: id,
+		objectId: options.objectId,
 		type: ObjectType.rect,
-		left: x,
-		top: y,
-		fill: fill,
+		left: options.left,
+		top: options.top,
+		fill: options.color,
 		width: defaultWidth,
 		height: defaultHeight,
 		objectCaching: false,
@@ -47,39 +47,33 @@ export const createRect = (id: string, x: number, y: number, fill: string) => {
 	return rect;
 };
 
-export const createTextBox = (id: string, x: number, y: number, fontSize: number, defaultText = 'Text...') => {
-	const defaultTop = y + 10;
-	const defaultLeft = x + 10;
+export const createTextBox = (options: TextBoxOptions) => {
+	const defaultTop = options.top + 10;
+	const defaultLeft = options.left + 10;
 	const defaultWidth = 280;
+	const defaultText = 'Text...';
 
-	const textbox = new fabric.Textbox(defaultText, {
+	const textbox = new fabric.Textbox(options.text || defaultText, {
 		type: ObjectType.text,
 		top: defaultTop,
 		left: defaultLeft,
-		objectId: id,
+		objectId: options.objectId,
 		width: defaultWidth,
 		objectCaching: false,
 		splitByGrapheme: true,
-		fontSize: fontSize,
+		fontSize: options.fontSize,
 		isSocketObject: false,
 	});
 
 	return textbox;
 };
 
-export const createPostIt = (
-	id: string,
-	x: number,
-	y: number,
-	textBox: fabric.Textbox,
-	nameLabel: fabric.Text,
-	backgroundRect: fabric.Rect
-) => {
-	const postit = new fabric.Group([backgroundRect, textBox, nameLabel], {
-		objectId: id,
+export const createPostIt = (options: PostItOptions) => {
+	const postit = new fabric.Group([options.backgroundRect, options.textBox, options.nameLabel], {
+		objectId: options.objectId,
 		type: ObjectType.postit,
-		left: x,
-		top: y,
+		left: options.left,
+		top: options.top,
 		objectCaching: false,
 		isSocketObject: false,
 	});
@@ -170,12 +164,26 @@ export const setPreventResizeEvent = (id: string, canvas: fabric.Canvas, backgro
 	});
 };
 
-export const addPostIt = (canvas: fabric.Canvas, x: number, y: number, fontSize: number, fill: string) => {
+export const addPostIt = (
+	canvas: fabric.Canvas,
+	x: number,
+	y: number,
+	fontSize: number,
+	fill: string,
+	creator: string
+) => {
 	const id = v4();
-	const nameLabel = createNameLabel(id, 'NAME', x, y);
-	const textBox = createTextBox(id, x, y, fontSize);
-	const backgroundRect = createRect(id, x, y, fill);
-	const postit = createPostIt(id, x, y, textBox, nameLabel, backgroundRect);
+	const nameLabel = createNameLabel({ objectId: id, text: creator, left: x, top: y });
+	const textBox = createTextBox({ objectId: id, left: x, top: y, fontSize: 40 });
+	const backgroundRect = createRect({ objectId: id, left: x, top: y, color: fill });
+	const postit = createPostIt({
+		objectId: id,
+		left: x,
+		top: y,
+		textBox: textBox,
+		nameLabel: nameLabel,
+		backgroundRect: backgroundRect,
+	});
 
 	setLimitHeightEvent(canvas, textBox, backgroundRect);
 	setObjectEditEvent(canvas, postit, textBox);
@@ -186,14 +194,14 @@ export const addPostIt = (canvas: fabric.Canvas, x: number, y: number, fontSize:
 
 // Section
 
-export const createSectionTitle = (id: string, text: string, x: number, y: number) => {
-	const defaultLeft = x + 10;
-	const defaultTop = y - 25;
+export const createSectionTitle = (options: SectionTitleOptions) => {
+	const defaultLeft = options.left + 10;
+	const defaultTop = options.top - 25;
 	const defaultFontSize = 15;
 
-	const title = new fabric.IText(text, {
+	const title = new fabric.IText(options.text || 'SECTION', {
 		type: ObjectType.title,
-		objectId: id,
+		objectId: options.objectId,
 		top: defaultTop,
 		left: defaultLeft,
 		fontSize: defaultFontSize,
@@ -204,37 +212,30 @@ export const createSectionTitle = (id: string, text: string, x: number, y: numbe
 	return title;
 };
 
-export const createSection = (
-	id: string,
-	x: number,
-	y: number,
-	sectionTitle: fabric.IText,
-	titleBackground: fabric.Rect,
-	backgroundRect: fabric.Rect
-) => {
-	const section = new fabric.Group([backgroundRect, titleBackground, sectionTitle], {
+export const createSection = (options: SectionOption) => {
+	const section = new fabric.Group([options.backgroundRect, options.titleBackground, options.sectionTitle], {
 		type: ObjectType.section,
 		isSocketObject: false,
-		objectId: id,
-		left: x,
-		top: y,
+		objectId: options.objectId,
+		left: options.left,
+		top: options.top,
 		objectCaching: false,
 	});
 	return section;
 };
 
-export const createTitleBackground = (id: string, x: number, y: number, fill: string) => {
+export const createTitleBackground = (options: TitleBackgroundOptions) => {
 	const defaultWidth = 70;
 	const defaultHeight = 20;
-	const defaultLeft = x + 7;
-	const defaultTop = y - 25;
+	const defaultLeft = options.left + 7;
+	const defaultTop = options.top - 25;
 
 	const rect = new fabric.Rect({
 		type: ObjectType.rect,
-		objectId: id,
+		objectId: options.objectId,
 		left: defaultLeft,
 		top: defaultTop,
-		fill: fill,
+		fill: options.color,
 		width: defaultWidth,
 		height: defaultHeight,
 		objectCaching: false,
@@ -261,10 +262,17 @@ export const setLimitChar = (canvas: fabric.Canvas, title: fabric.IText, backgro
 
 export const addSection = (canvas: fabric.Canvas, x: number, y: number, fill: string) => {
 	const id = v4();
-	const sectionTitle = createSectionTitle(id, 'SECTION', x, y);
-	const sectionBackground = createTitleBackground(id, x, y, fill);
-	const backgroundRect = createRect(id, x, y, fill);
-	const section = createSection(id, x, y, sectionTitle, sectionBackground, backgroundRect);
+	const sectionTitle = createSectionTitle({ objectId: id, text: 'SECTION', left: x, top: y });
+	const sectionBackground = createTitleBackground({ objectId: id, left: x, top: y, color: fill });
+	const backgroundRect = createRect({ objectId: id, left: x, top: y, color: fill });
+	const section = createSection({
+		objectId: id,
+		left: x,
+		top: y,
+		sectionTitle,
+		titleBackground: sectionBackground,
+		backgroundRect,
+	});
 
 	setObjectEditEvent(canvas, section, sectionTitle);
 	setLimitChar(canvas, sectionTitle, sectionBackground);

--- a/frontend/src/utils/object.utils.ts
+++ b/frontend/src/utils/object.utils.ts
@@ -1,6 +1,4 @@
-import { colorChips } from '@data/workspace-object-color';
 import { fabric } from 'fabric';
-import { title } from 'process';
 import { v4 } from 'uuid';
 
 export const setEditMenu = (object: fabric.Object) => {
@@ -71,6 +69,7 @@ const createPostIt = (
 	backgroundRect: fabric.Rect
 ) => {
 	const postit = new fabric.Group([backgroundRect, textBox, nameLabel], {
+		type: 'postit',
 		objectId: id,
 		left: x,
 		top: y,
@@ -204,6 +203,7 @@ const createSection = (
 	backgroundRect: fabric.Rect
 ) => {
 	const section = new fabric.Group([backgroundRect, titleBackground, sectionTitle], {
+		type: 'section',
 		objectId: id,
 		left: x,
 		top: y,
@@ -246,11 +246,11 @@ const setLimitChar = (canvas: fabric.Canvas, title: fabric.IText, background: fa
 	});
 };
 
-export const addSection = (canvas: fabric.Canvas, x: number, y: number) => {
+export const addSection = (canvas: fabric.Canvas, x: number, y: number, fill: string) => {
 	const id = v4();
 	const sectionTitle = createSectionTitle(id, 'SECTION', x, y);
-	const sectionBackground = createTitleBackground(id, x, y, 'pink');
-	const backgroundRect = createRect(id, x, y, 'MediumSlateBlue');
+	const sectionBackground = createTitleBackground(id, x, y, fill);
+	const backgroundRect = createRect(id, x, y, fill);
 	const section = createSection(id, x, y, sectionTitle, sectionBackground, backgroundRect);
 
 	setObjectEditEvent(canvas, section, sectionTitle);

--- a/frontend/src/utils/object.utils.ts
+++ b/frontend/src/utils/object.utils.ts
@@ -76,7 +76,6 @@ export const createPostIt = (
 	backgroundRect: fabric.Rect
 ) => {
 	const postit = new fabric.Group([backgroundRect, textBox, nameLabel], {
-		type: 'postit',
 		objectId: id,
 		type: ObjectType.postit,
 		left: x,
@@ -100,7 +99,7 @@ export const setLimitHeightEvent = (canvas: fabric.Canvas, textBox: fabric.Textb
 	textBox.on('changed', handler);
 };
 
-const setObjectEditEvent = (
+export const setObjectEditEvent = (
 	canvas: fabric.Canvas,
 	groupObject: fabric.Group,
 	textBox: fabric.Textbox | fabric.IText
@@ -187,23 +186,25 @@ export const addPostIt = (canvas: fabric.Canvas, x: number, y: number, fontSize:
 
 // Section
 
-const createSectionTitle = (id: string, text: string, x: number, y: number) => {
+export const createSectionTitle = (id: string, text: string, x: number, y: number) => {
 	const defaultLeft = x + 10;
 	const defaultTop = y - 25;
 	const defaultFontSize = 15;
 
 	const title = new fabric.IText(text, {
+		type: ObjectType.title,
 		objectId: id,
 		top: defaultTop,
 		left: defaultLeft,
 		fontSize: defaultFontSize,
+		isSocketObject: false,
 		objectCaching: false,
 	});
 
 	return title;
 };
 
-const createSection = (
+export const createSection = (
 	id: string,
 	x: number,
 	y: number,
@@ -212,7 +213,8 @@ const createSection = (
 	backgroundRect: fabric.Rect
 ) => {
 	const section = new fabric.Group([backgroundRect, titleBackground, sectionTitle], {
-		type: 'section',
+		type: ObjectType.section,
+		isSocketObject: false,
 		objectId: id,
 		left: x,
 		top: y,
@@ -221,13 +223,14 @@ const createSection = (
 	return section;
 };
 
-const createTitleBackground = (id: string, x: number, y: number, fill: string) => {
+export const createTitleBackground = (id: string, x: number, y: number, fill: string) => {
 	const defaultWidth = 70;
 	const defaultHeight = 20;
 	const defaultLeft = x + 7;
 	const defaultTop = y - 25;
 
 	const rect = new fabric.Rect({
+		type: ObjectType.rect,
 		objectId: id,
 		left: defaultLeft,
 		top: defaultTop,
@@ -235,6 +238,7 @@ const createTitleBackground = (id: string, x: number, y: number, fill: string) =
 		width: defaultWidth,
 		height: defaultHeight,
 		objectCaching: false,
+		isSocketObject: false,
 		rx: 10,
 		ry: 10,
 	});
@@ -242,7 +246,7 @@ const createTitleBackground = (id: string, x: number, y: number, fill: string) =
 	return rect;
 };
 
-const setLimitChar = (canvas: fabric.Canvas, title: fabric.IText, background: fabric.Rect) => {
+export const setLimitChar = (canvas: fabric.Canvas, title: fabric.IText, background: fabric.Rect) => {
 	title.on('editing:entered', () => {
 		title.hiddenTextarea?.setAttribute('maxlength', '15');
 	});


### PR DESCRIPTION
### 이슈명
- #126 

### 작업내용
- 함수형(?)으로 Section Object 구현
  - section 타이틀 배경은 동적으로 렌더링
- object index leveling 추가
  - object 추가 될 때 마다 postit이 맨 위로 오게 설정
### 캡처화면
![section1](https://user-images.githubusercontent.com/72279836/204516806-8b635bc1-8e8a-4037-8a11-90a31e96f616.gif)
![section2](https://user-images.githubusercontent.com/72279836/204517137-0638492b-df91-4ead-b107-7c511e027079.gif)


### 의문점
- 섹션이 움직이면 안에 있는 PostIt 같이 움직이면 좋겠죠...? ㅎㅎ...