### PR TITLE
[feat] 권한에 따른 인터페이스 처리 closes #128

### DIFF
--- a/frontend/src/context/user.ts
+++ b/frontend/src/context/user.ts
@@ -16,3 +16,8 @@ export const userProfileState = selector({
 		return await User.getProfile();
 	},
 });
+
+export const myInfoInWorkspaceState = atom({
+	key: 'infoInWorkspace',
+	default: { userId: '', nickname: '', color: '', role: 0 },
+});

--- a/frontend/src/context/user.ts
+++ b/frontend/src/context/user.ts
@@ -19,5 +19,5 @@ export const userProfileState = selector({
 
 export const myInfoInWorkspaceState = atom({
 	key: 'infoInWorkspace',
-	default: { userId: '', nickname: '', color: '', role: 0 },
+	default: { userId: '', nickname: '', color: '', role: 2 },
 });

--- a/frontend/src/context/user.ts
+++ b/frontend/src/context/user.ts
@@ -1,6 +1,7 @@
 import { ProfileData } from '@api/user.types';
 import { atom, selector } from 'recoil';
 import { User } from '@api/user';
+import { workspaceRole } from '@data/workspace-role';
 
 export const authState = atom({
 	key: 'auth',
@@ -19,5 +20,5 @@ export const userProfileState = selector({
 
 export const myInfoInWorkspaceState = atom({
 	key: 'infoInWorkspace',
-	default: { userId: '', nickname: '', color: '', role: 2 },
+	default: { userId: '', nickname: '', color: '', role: workspaceRole.GUEST },
 });

--- a/frontend/src/context/user.ts
+++ b/frontend/src/context/user.ts
@@ -20,5 +20,7 @@ export const userProfileState = selector({
 
 export const myInfoInWorkspaceState = atom({
 	key: 'infoInWorkspace',
-	default: { userId: '', nickname: '', color: '', role: workspaceRole.GUEST },
+	default: { userId: '', nickname: '', color: '', role: workspaceRole.GUEST as Role },
 });
+
+type Role = 0 | 1 | 2;

--- a/frontend/src/data/workspace-role.ts
+++ b/frontend/src/data/workspace-role.ts
@@ -1,0 +1,9 @@
+interface RoleType {
+	[index: string]: number;
+}
+
+export const workspaceRole: RoleType = {
+	OWNER: 2,
+	EDITOR: 1,
+	GUEST: 0,
+};

--- a/frontend/src/pages/main/workspace-menu/index.tsx
+++ b/frontend/src/pages/main/workspace-menu/index.tsx
@@ -7,6 +7,7 @@ import { WorkspaceMenuProps } from './index.types';
 import DeleteModal from '../delete-modal';
 import RenameModal from '../rename-modal';
 import { Workspace } from '@api/workspace';
+import { workspaceRole } from '@data/workspace-role';
 
 function WorkspaceMenu({ workspaceId, role, workspaceName, setWorkspaceList }: WorkspaceMenuProps) {
 	const { isOpenModal, modalRef, toggleOpenModal } = useModal();
@@ -34,7 +35,7 @@ function WorkspaceMenu({ workspaceId, role, workspaceName, setWorkspaceList }: W
 		<>
 			<WorkspaceMenuList>
 				<WorkspaceMenuItem>Open</WorkspaceMenuItem>
-				{role == 2 && (
+				{role === workspaceRole.OWNER && (
 					<>
 						<WorkspaceMenuItem onClick={openReanmeModal}>Rename</WorkspaceMenuItem>
 						<WorkspaceMenuItem onClick={openDeleteModal}>Delete</WorkspaceMenuItem>

--- a/frontend/src/pages/workspace/layout/index.tsx
+++ b/frontend/src/pages/workspace/layout/index.tsx
@@ -1,6 +1,9 @@
 import Modal from '@components/modal';
+import { myInfoInWorkspaceState } from '@context/user';
+import { workspaceRole } from '@data/workspace-role';
 import useModal from '@hooks/useModal';
 import { useCallback, useState } from 'react';
+import { useRecoilValue } from 'recoil';
 import Header from '../header';
 import ShareModal from '../share-modal';
 import Toolkit from '../toolkit';
@@ -8,6 +11,7 @@ import Toolkit from '../toolkit';
 function Layout({ workspaceId }: { workspaceId: string }) {
 	const { isOpenModal, openModal, modalRef, closeModal } = useModal();
 	const [modalContent, setModalContent] = useState(<></>);
+	const myInfoInWorkspace = useRecoilValue(myInfoInWorkspaceState);
 
 	const openShareModal = useCallback(() => {
 		openModal();
@@ -17,7 +21,7 @@ function Layout({ workspaceId }: { workspaceId: string }) {
 	return (
 		<>
 			<Header workspaceId={workspaceId} openShareModal={openShareModal} />
-			<Toolkit />
+			{myInfoInWorkspace.role !== workspaceRole.GUEST && <Toolkit />}
 
 			<Modal isOpen={isOpenModal} modalRef={modalRef} width={600} height={400}>
 				{modalContent}

--- a/frontend/src/pages/workspace/whiteboard-canvas/index.tsx
+++ b/frontend/src/pages/workspace/whiteboard-canvas/index.tsx
@@ -1,13 +1,11 @@
 import { WhiteboardCanvasLayout } from './index.style';
 import useCanvas from './useCanvas';
 import useSocket from './useSocket';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import ContextMenu from '@components/context-menu';
 import ObjectEditMenu from '../object-edit-menu';
 import { colorChips } from '@data/workspace-object-color';
-import { toolItems } from '@data/workspace-tool';
-import { useRecoilState, useRecoilValue } from 'recoil';
-import { cursorState } from '@context/workspace';
+import { useRecoilValue } from 'recoil';
 import useCanvasToSocket from './useCanvasToSocket';
 import { myInfoInWorkspaceState } from '@context/user';
 import { workspaceRole } from '@data/workspace-role';
@@ -17,30 +15,7 @@ function WhiteboardCanvas() {
 	const { socket } = useSocket(canvas);
 
 	const { isOpen, menuRef, menuPosition } = useCanvasToSocket({ canvas, socket });
-	const [cursor, setCursor] = useRecoilState(cursorState);
 	const myInfoInWorkspace = useRecoilValue(myInfoInWorkspaceState);
-
-	useEffect(() => {
-		if (!canvas.current) return;
-
-		const fabricCanvas = canvas.current as fabric.Canvas;
-		if (myInfoInWorkspace.role === workspaceRole.GUEST) {
-			if (cursor.type !== toolItems.MOVE) setCursor({ ...cursor, type: toolItems.MOVE });
-			fabricCanvas.defaultCursor = 'grab';
-			fabricCanvas.selection = false;
-		} else {
-			if (cursor.type === toolItems.MOVE) {
-				fabricCanvas.defaultCursor = 'grab';
-				fabricCanvas.selection = false;
-			} else if (cursor.type === toolItems.SECTION || cursor.type === toolItems.POST_IT) {
-				fabricCanvas.defaultCursor = 'context-menu';
-				fabricCanvas.selection = true;
-			} else {
-				fabricCanvas.defaultCursor = 'default';
-				fabricCanvas.selection = true;
-			}
-		}
-	}, [cursor, myInfoInWorkspace]);
 
 	// object color 수정 초안
 	const [color, setColor] = useState(colorChips[0]); // 나중에 선택된 object의 color로 대체 예정

--- a/frontend/src/pages/workspace/whiteboard-canvas/useCanvas.ts
+++ b/frontend/src/pages/workspace/whiteboard-canvas/useCanvas.ts
@@ -8,16 +8,20 @@ import {
 	initGrid,
 	deleteObject,
 	setObjectIndexLeveling,
+	setCursorMode,
 } from '@utils/fabric.utils';
 import { toolItems } from '@data/workspace-tool';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { cursorState, zoomState } from '@context/workspace';
 import { CanvasType } from './types';
+import { myInfoInWorkspaceState } from '@context/user';
+import { workspaceRole } from '@data/workspace-role';
 
 function useCanvas() {
 	const canvas = useRef<fabric.Canvas | null>(null);
 	const [zoom, setZoom] = useRecoilState(zoomState);
 	const cursor = useRecoilValue(cursorState);
+	const myInfoInWorkspace = useRecoilValue(myInfoInWorkspaceState);
 
 	useEffect(() => {
 		if (canvas.current && zoom.event === 'control')
@@ -38,24 +42,22 @@ function useCanvas() {
 		if (!canvas.current) return;
 
 		const fabricCanvas = canvas.current as fabric.Canvas;
-		if (cursor.type === toolItems.SECTION || cursor.type === toolItems.POST_IT) {
-			fabricCanvas.defaultCursor = 'context-menu';
-			fabricCanvas.selection = true;
-			if (cursor.type === toolItems.SECTION) fabricCanvas.mode = CanvasType.section;
-			else fabricCanvas.mode = CanvasType.postit;
-		} else if (cursor.type === toolItems.MOVE) {
-			fabricCanvas.defaultCursor = 'grab';
-			fabricCanvas.mode = CanvasType.move;
-			fabricCanvas.selection = false;
-		} else if (cursor.type === toolItems.SELECT) {
-			fabricCanvas.defaultCursor = 'default';
-			fabricCanvas.mode = CanvasType.select;
-			fabricCanvas.selection = true;
+		if (myInfoInWorkspace.role === workspaceRole.GUEST) {
+			setCursorMode(fabricCanvas, 'grab', CanvasType.move, false);
 		} else {
-			fabricCanvas.defaultCursor = 'default';
-			fabricCanvas.mode = CanvasType.draw;
+			if (cursor.type === toolItems.SECTION) {
+				setCursorMode(fabricCanvas, 'context-menu', CanvasType.section, true);
+			} else if (cursor.type === toolItems.POST_IT) {
+				setCursorMode(fabricCanvas, 'context-menu', CanvasType.postit, true);
+			} else if (cursor.type === toolItems.MOVE) {
+				setCursorMode(fabricCanvas, 'grab', CanvasType.move, false);
+			} else if (cursor.type === toolItems.SELECT) {
+				setCursorMode(fabricCanvas, 'default', CanvasType.select, true);
+			} else {
+				setCursorMode(fabricCanvas, 'default', CanvasType.draw, true);
+			}
 		}
-	}, [cursor]);
+	}, [cursor, myInfoInWorkspace]);
 
 	const initCanvas = () => {
 		const grid = 50;

--- a/frontend/src/pages/workspace/whiteboard-canvas/useSocket.ts
+++ b/frontend/src/pages/workspace/whiteboard-canvas/useSocket.ts
@@ -1,15 +1,16 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useRef, useCallback } from 'react';
 import { useParams } from 'react-router-dom';
 import { io, Socket } from 'socket.io-client';
-import { ClientToServerEvents, Member, MemberInCanvas, ServerToClientEvents } from './types';
-import { useRecoilState } from 'recoil';
+import { ClientToServerEvents, MemberInCanvas, ServerToClientEvents } from './types';
+import { useRecoilState, useSetRecoilState } from 'recoil';
 import { membersState } from '@context/workspace';
 import { fabric } from 'fabric';
 import { createCursorObject, createObjectFromServer, moveCursorFromServer } from '@utils/object-from-server';
+import { myInfoInWorkspaceState } from '@context/user';
 
 function useSocket(canvas: React.MutableRefObject<fabric.Canvas | null>) {
 	// 자신의 정보 role을 이용해 작업하기 위해 생성
-	const myInfoInWorkspace = useRef<Member>();
+	const [myInfoInWorkspace, setMyInfoInWorkspace] = useRecoilState(myInfoInWorkspaceState);
 	const [members, setMembers] = useRecoilState(membersState);
 
 	const socket = useRef<Socket<ServerToClientEvents, ClientToServerEvents> | null>(null);
@@ -19,7 +20,8 @@ function useSocket(canvas: React.MutableRefObject<fabric.Canvas | null>) {
 	const { workspaceId } = useParams();
 
 	const isMessageByMe = (userId: string) => {
-		return myInfoInWorkspace.current?.userId === userId;
+		console.log(myInfoInWorkspace);
+		return myInfoInWorkspace.userId === userId;
 	};
 
 	useEffect(() => {
@@ -35,7 +37,7 @@ function useSocket(canvas: React.MutableRefObject<fabric.Canvas | null>) {
 		});
 
 		socket.current.on('init', ({ members, objects, userData }) => {
-			myInfoInWorkspace.current = userData;
+			setMyInfoInWorkspace(userData);
 			setMembers(members);
 			//todo: objects 업데이트
 		});
@@ -105,7 +107,6 @@ function useSocket(canvas: React.MutableRefObject<fabric.Canvas | null>) {
 		isConnected,
 		socket,
 		membersInCanvas,
-		myInfoInWorkspace,
 	};
 }
 

--- a/frontend/src/pages/workspace/whiteboard-canvas/useSocket.ts
+++ b/frontend/src/pages/workspace/whiteboard-canvas/useSocket.ts
@@ -1,8 +1,8 @@
-import { useState, useEffect, useRef, useCallback } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useParams } from 'react-router-dom';
 import { io, Socket } from 'socket.io-client';
-import { ClientToServerEvents, MemberInCanvas, ServerToClientEvents } from './types';
-import { useRecoilState, useSetRecoilState } from 'recoil';
+import { ClientToServerEvents, Member, MemberInCanvas, ServerToClientEvents } from './types';
+import { useRecoilState } from 'recoil';
 import { membersState } from '@context/workspace';
 import { fabric } from 'fabric';
 import { createCursorObject, createObjectFromServer, moveCursorFromServer } from '@utils/object-from-server';
@@ -11,6 +11,7 @@ import { myInfoInWorkspaceState } from '@context/user';
 function useSocket(canvas: React.MutableRefObject<fabric.Canvas | null>) {
 	// 자신의 정보 role을 이용해 작업하기 위해 생성
 	const [myInfoInWorkspace, setMyInfoInWorkspace] = useRecoilState(myInfoInWorkspaceState);
+	const myInfoInWorkspaceRef = useRef<Member>();
 	const [members, setMembers] = useRecoilState(membersState);
 
 	const socket = useRef<Socket<ServerToClientEvents, ClientToServerEvents> | null>(null);
@@ -20,9 +21,12 @@ function useSocket(canvas: React.MutableRefObject<fabric.Canvas | null>) {
 	const { workspaceId } = useParams();
 
 	const isMessageByMe = (userId: string) => {
-		console.log(myInfoInWorkspace);
-		return myInfoInWorkspace.userId === userId;
+		return myInfoInWorkspaceRef.current?.userId === userId;
 	};
+
+	useEffect(() => {
+		myInfoInWorkspaceRef.current = myInfoInWorkspace;
+	}, [myInfoInWorkspace]);
 
 	useEffect(() => {
 		socket.current = io(`/workspace/${workspaceId}`);

--- a/frontend/src/pages/workspace/whiteboard-canvas/useSocket.ts
+++ b/frontend/src/pages/workspace/whiteboard-canvas/useSocket.ts
@@ -37,6 +37,8 @@ function useSocket(canvas: React.MutableRefObject<fabric.Canvas | null>) {
 		});
 
 		socket.current.on('init', ({ members, objects, userData }) => {
+			console.log(userData);
+			console.log(members);
 			setMyInfoInWorkspace(userData);
 			setMembers(members);
 			//todo: objects 업데이트

--- a/frontend/src/utils/fabric.utils.ts
+++ b/frontend/src/utils/fabric.utils.ts
@@ -110,10 +110,10 @@ export const addObject = (canvas: fabric.Canvas, creator: string) => {
 		const x = (evt.clientX - vpt[4]) / vpt[3];
 		const y = (evt.clientY - vpt[5]) / vpt[3];
 		if (canvas.mode === CanvasType.section && !canvas.getActiveObject()) {
-			addSection(canvas, x, y);
+			addSection(canvas, x, y, colorChips[8]);
 		} else if (canvas.mode === CanvasType.postit && !canvas.getActiveObject()) {
 			//todo 색 정보 받아와야함
-			addPostIt(canvas, x, y, 40, 'pink');
+			addPostIt(canvas, x, y, 40, colorChips[0], creator);
 		}
 	});
 };

--- a/frontend/src/utils/fabric.utils.ts
+++ b/frontend/src/utils/fabric.utils.ts
@@ -1,5 +1,5 @@
 import { colorChips } from '@data/workspace-object-color';
-import { ObjectType } from '@pages/workspace/whiteboard-canvas/types';
+import { ObjectType, CanvasType } from '@pages/workspace/whiteboard-canvas/types';
 import { fabric } from 'fabric';
 import { SetterOrUpdater } from 'recoil';
 import { v4 } from 'uuid';
@@ -54,7 +54,7 @@ export const initZoom = (
 export const initDragPanning = (canvas: fabric.Canvas) => {
 	canvas.on('mouse:down', function (opt) {
 		const evt = opt.e;
-		if (canvas.mode === 'move') {
+		if (canvas.mode === CanvasType.move) {
 			canvas.defaultCursor = 'grabbing';
 			canvas.isDragging = true;
 			canvas.lastPosX = evt.clientX;
@@ -78,7 +78,7 @@ export const initDragPanning = (canvas: fabric.Canvas) => {
 	canvas.on('mouse:up', function (opt) {
 		if (canvas.viewportTransform) canvas.setViewportTransform(canvas.viewportTransform);
 
-		if (canvas.mode === 'move') {
+		if (canvas.mode === CanvasType.move) {
 			canvas.defaultCursor = 'grab';
 			canvas.isDragging = false;
 		}
@@ -109,10 +109,11 @@ export const addObject = (canvas: fabric.Canvas, creator: string) => {
 		if (!vpt) return;
 		const x = (evt.clientX - vpt[4]) / vpt[3];
 		const y = (evt.clientY - vpt[5]) / vpt[3];
-		if (canvas.mode === 'section' && !canvas.getActiveObject()) {
-			addSection(canvas, x, y, colorChips[8]);
-		} else if (canvas.mode === 'postit' && !canvas.getActiveObject()) {
-			addPostIt(canvas, x, y, 40, colorChips[0], creator);
+		if (canvas.mode === CanvasType.section && !canvas.getActiveObject()) {
+			addSection(canvas, x, y);
+		} else if (canvas.mode === CanvasType.postit && !canvas.getActiveObject()) {
+			//todo 색 정보 받아와야함
+			addPostIt(canvas, x, y, 40, 'pink');
 		}
 	});
 };
@@ -147,4 +148,10 @@ export const setObjectIndexLeveling = (canvas: fabric.Canvas) => {
 			obj.bringToFront();
 		});
 	});
+};
+
+export const setCursorMode = (canvas: fabric.Canvas, cursor: string, mode: CanvasType, selectable: boolean) => {
+	canvas.defaultCursor = cursor;
+	canvas.mode = mode;
+	canvas.forEachObject((obj) => (obj.selectable = selectable));
 };


### PR DESCRIPTION
### 이슈명
- #128 

### 작업 사항
- Guest 권한(`role: 0`)인 경우 Toolkit을 사용할 수 없고 커서모드를 무조건 move로 사용 가능하도록 설정
  - move mode 시 캔버스에 올라간 모든 object를 `selectable: false`로 해두어 object를 선택할 수 없게 설정
- `init`시 초기화한 정보를 전역 상태에 저장해 다른 컴포넌트에서 사용할 수 있게 하고, ref에 저장해 해당 hook 내에서 사용할 수 있게 설정

### 참고사항
- `myInfoInWorkspace`를 전역 state로 관리하는 경우 setRecoilState 후에 effect 안에서 값이 업데이트되지 않기 때문에 useSocket 안에서만 사용할 수 있는 ref를 추가적으로 선언해주거나 아니면 state가 바뀔 때마다 이벤트를 off 후 새로 on해야 할 것 같은데 ref를 선언하는게 그나마 효율적이라 생각해서 그런 방식으로 구현했습니다. 더 좋은 방법이 있으시다면 말씀해주세요!