### PR TITLE
[feat] Text 편집 기능 구조 변경 closes #127

### DIFF
--- a/frontend/patches/@types+fabric+4.5.12.patch
+++ b/frontend/patches/@types+fabric+4.5.12.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@types/fabric/fabric-impl.d.ts b/node_modules/@types/fabric/fabric-impl.d.ts
-index 107db96..79e09cd 100755
+index 107db96..b83c3ba 100644
 --- a/node_modules/@types/fabric/fabric-impl.d.ts
 +++ b/node_modules/@types/fabric/fabric-impl.d.ts
 @@ -1693,6 +1693,10 @@ export class StaticCanvas {
@@ -9,7 +9,7 @@ index 107db96..79e09cd 100755
 +    isDragging?:boolean;
 +    lastPosX?:number;
 +    lastPosY?:number;
-+    mode: 'postit' | 'section' | 'move' | 'select' | 'draw';
++    mode: 'postit' | 'section' | 'move' | 'select' | 'draw' | 'edit';
      /**
       * When true, objects can be transformed by one side (unproportionally)
       * when dragged on the corners that normally would not do that.
@@ -24,10 +24,10 @@ index 107db96..79e09cd 100755
       * If you modify, certain parts of Fabric (such as JSON loading) won't work correctly.
       */
 -    type?: string | undefined;
-+    type: "postit" | "section" | "draw" | "text" | "title" | "nameText" | "cursor" | "rect" | "line";
++    type: "postit" | "section" | "draw" | "text" | "title" | "nameText" | "cursor" | "rect" | "line" | "editable";
 +
 +    isSocketObject: boolean;
-     
+ 
      /**
       * Horizontal origin of transformation of an object (one of "left", "right", "center")
 @@ -4163,7 +4170,6 @@ export class Rect extends Object {

--- a/frontend/src/pages/workspace/whiteboard-canvas/types/workspace-object.types.ts
+++ b/frontend/src/pages/workspace/whiteboard-canvas/types/workspace-object.types.ts
@@ -38,6 +38,7 @@ export const ObjectType = {
 	cursor: 'cursor',
 	rect: 'rect',
 	line: 'line',
+	editable: 'editable',
 } as const;
 
 export type ObjectType = typeof ObjectType[keyof typeof ObjectType];

--- a/frontend/src/types/fabric-options.d.ts
+++ b/frontend/src/types/fabric-options.d.ts
@@ -15,6 +15,7 @@ interface SectionOption {
 }
 
 interface SectionTitleOptions {
+	editable?: boolean;
 	objectId: string;
 	text?: string;
 	left: number;
@@ -36,6 +37,7 @@ interface TextBoxOptions {
 	top: number;
 	fontSize: number;
 	text?: string;
+	editable?: boolean;
 }
 
 interface RectOptions {

--- a/frontend/src/utils/object-from-server.ts
+++ b/frontend/src/utils/object-from-server.ts
@@ -11,7 +11,7 @@ import {
 	createRect,
 	createTextBox,
 	setLimitHeightEvent,
-	setObjectEditEvent,
+	setPostItEditEvent,
 	setPreventResizeEvent,
 } from './object.utils';
 
@@ -27,6 +27,8 @@ export const createPostitFromServer = (canvas: fabric.Canvas, newObject: ObjectD
 	if (!left || !top || !fontSize || !color || !text || !width || !height) return;
 	const nameLabel = createNameLabel({ objectId, text: 'NAME', left, top });
 	const textBox = createTextBox({ objectId, left, top, fontSize, text });
+	const editableTextBox = createTextBox({ objectId, left, top, fontSize, text });
+
 	const backgroundRect = createRect({ objectId, left, top, color });
 	backgroundRect.set({
 		width,
@@ -47,8 +49,9 @@ export const createPostitFromServer = (canvas: fabric.Canvas, newObject: ObjectD
 		isSocketObject: true,
 	});
 	setLimitHeightEvent(canvas, textBox, backgroundRect);
-	setObjectEditEvent(canvas, postit, textBox);
-	setPreventResizeEvent(postit.objectId, canvas, backgroundRect);
+	setLimitHeightEvent(canvas, editableTextBox, postit);
+	setPostItEditEvent(canvas, postit, editableTextBox, textBox);
+	setPreventResizeEvent(objectId, canvas, textBox, postit);
 	canvas.add(postit);
 };
 

--- a/frontend/src/utils/object.utils.ts
+++ b/frontend/src/utils/object.utils.ts
@@ -11,7 +11,7 @@ export const setEditMenu = (object: fabric.Object) => {
 };
 
 export const createNameLabel = (options: NameLabelOptions) => {
-	const defaultLeft = options.left + 10;
+	const defaultLeft = options.left + 300 * 0.05;
 	const defaultTop = options.top + 275;
 	const defaultFontSize = 15;
 
@@ -48,9 +48,9 @@ export const createRect = (options: RectOptions) => {
 };
 
 export const createTextBox = (options: TextBoxOptions) => {
-	const defaultTop = options.top + 10;
-	const defaultLeft = options.left + 10;
-	const defaultWidth = 280;
+	const defaultTop = options.top + 300 * 0.05;
+	const defaultLeft = options.left + 300 * 0.05;
+	const defaultWidth = 300 * 0.9;
 	const defaultText = 'Text...';
 
 	const textbox = new fabric.Textbox(options.text || defaultText, {
@@ -102,19 +102,18 @@ export const setLimitHeightEvent = (
 export const setPostItEditEvent = (
 	canvas: fabric.Canvas,
 	groupObject: fabric.Group,
-	editableTextBox: fabric.Textbox | fabric.IText,
-	textBox: fabric.Textbox | fabric.IText
+	editableTextBox: fabric.Textbox,
+	textBox: fabric.Textbox
 ) => {
 	groupObject.on('mousedblclick', (e) => {
 		textBox.set({ visible: false });
-
 		canvas.add(editableTextBox);
 		canvas.setActiveObject(editableTextBox);
 		editableTextBox.enterEditing();
 		editableTextBox.set({
-			left: (groupObject?.left || 0) + groupObject.getScaledWidth() * 0.033,
-			top: (groupObject?.top || 0) + groupObject.getScaledHeight() * 0.033,
-			width: groupObject.getScaledWidth() * 0.93,
+			left: (groupObject?.left || 0) + groupObject.getScaledWidth() * 0.05,
+			top: (groupObject?.top || 0) + groupObject.getScaledHeight() * 0.05,
+			width: groupObject.getScaledWidth() * 0.9,
 			fontSize: textBox.fontSize,
 		});
 		editableTextBox.fire('changed');
@@ -128,7 +127,6 @@ export const setPostItEditEvent = (
 	editableTextBox.on('editing:exited', (e) => {
 		textBox.set({ visible: true });
 		canvas.remove(editableTextBox);
-
 		textBox.fire('changed');
 	});
 };
@@ -149,7 +147,7 @@ export const setPreventResizeEvent = (
 		obj.set({
 			scaleX: scaleX,
 			scaleY: scaleY,
-			width: (group?.getScaledWidth() || 0) * 0.93,
+			width: (group?.getScaledWidth() || 0) * 0.9,
 		});
 		obj.fire('changed');
 	});
@@ -167,8 +165,6 @@ export const addPostIt = (
 	const nameLabel = createNameLabel({ objectId: id, text: creator, left: x, top: y });
 	const textBox = createTextBox({ objectId: id, left: x, top: y, fontSize: fontSize });
 	const editableTextBox = createTextBox({ objectId: id, left: x, top: y, fontSize: 40, editable: true });
-	console.log('textbox', textBox);
-	console.log('edit', editableTextBox);
 	const backgroundRect = createRect({ objectId: id, left: x, top: y, color: fill });
 	const postit = createPostIt({
 		objectId: id,
@@ -262,8 +258,8 @@ export const setLimitChar = (
 export const setSectionEditEvent = (
 	canvas: fabric.Canvas,
 	groupObject: fabric.Group,
-	editableTitle: fabric.Textbox | fabric.IText,
-	sectionTitle: fabric.Textbox | fabric.IText
+	editableTitle: fabric.IText,
+	sectionTitle: fabric.IText
 ) => {
 	groupObject.on('mousedblclick', (e) => {
 		sectionTitle.set({ visible: false });


### PR DESCRIPTION
### 이슈명
- #127 

### 작업내용
- ObjectType에 editable 타입 추가
- 더블 클릭 시 editableText를 추가로 렌더링
- editable에서 changed 이벤트 이용해서 실제 Object(PostIt, Section)의 Text를 변경
- 실제 Object의 Text는 visible로 숨기기만 함
- editable Text와 실제 Text의 위치 동기화

### 캡처화면
![edit1](https://user-images.githubusercontent.com/72279836/204725828-7c5b56a3-2286-4299-b84a-4a435a486065.gif)

![edit2](https://user-images.githubusercontent.com/72279836/204725839-044804df-e21c-4196-b02d-e1c7e98f0f96.gif)


### 문제점
- editable Text랑 실제 Text랑 사이즈 싱크가 안맞아서 정돈을 해야겠다. (PostIt만 해당)