### PR TITLE
[hotfix] move 모드에서 포스트잇 편집되는 부분 수정 closes #176

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -7,7 +7,6 @@
     "": {
       "name": "frontend",
       "version": "0.1.0",
-      "hasInstallScript": true,
       "dependencies": {
         "@craco/craco": "^7.0.0",
         "@testing-library/jest-dom": "^5.16.5",

--- a/frontend/src/pages/workspace/whiteboard-canvas/types/workspace-object.types.ts
+++ b/frontend/src/pages/workspace/whiteboard-canvas/types/workspace-object.types.ts
@@ -51,6 +51,7 @@ export const CanvasType = {
 	move: 'move',
 	select: 'select',
 	draw: 'draw',
+	edit: 'edit',
 } as const;
 
 export type CanvasType = typeof CanvasType[keyof typeof CanvasType];

--- a/frontend/src/utils/fabric.utils.ts
+++ b/frontend/src/utils/fabric.utils.ts
@@ -36,9 +36,9 @@ export const initGrid = (canvas: fabric.Canvas, width: number, height: number, g
 	}
 
 	fabric.Image.fromURL(backgroundCanvas.toDataURL(), (img) => {
-		canvas.setBackgroundImage(img, canvas.renderAll.bind(canvas), {
+		canvas.setBackgroundImage(img, () => canvas.renderAll.bind(canvas), {
 			objectId: v4(),
-			type: ObjectType.rect,
+			type: ObjectType.line,
 			left: -width,
 			top: -height,
 			isSocketObject: false,

--- a/frontend/src/utils/fabric.utils.ts
+++ b/frontend/src/utils/fabric.utils.ts
@@ -6,8 +6,14 @@ import { v4 } from 'uuid';
 import { addPostIt, addSection } from './object.utils';
 
 export const initGrid = (canvas: fabric.Canvas, width: number, height: number, gridSize: number) => {
-	for (let i = -width / gridSize + 1; i <= (2 * width) / gridSize; i++) {
-		const lineY = new fabric.Line([i * gridSize, -height, i * gridSize, height * 2], {
+	const backgroundCanvas = new fabric.Canvas('', {
+		mode: canvas.mode,
+		height: height * 4,
+		width: width * 4,
+		backgroundColor: '#f1f1f1',
+	});
+	for (let i = 0; i <= (4 * width) / gridSize; i++) {
+		const lineY = new fabric.Line([i * gridSize, 0, i * gridSize, height * 4], {
 			objectId: v4(),
 			type: 'line',
 			stroke: '#ccc',
@@ -15,10 +21,10 @@ export const initGrid = (canvas: fabric.Canvas, width: number, height: number, g
 			isSocketObject: false,
 		});
 
-		canvas.sendToBack(lineY);
+		backgroundCanvas.add(lineY);
 	}
-	for (let i = -height / gridSize + 1; i <= (2 * height) / gridSize; i++) {
-		const lineX = new fabric.Line([-width, i * gridSize, width * 2, i * gridSize], {
+	for (let i = 0; i <= (4 * height) / gridSize; i++) {
+		const lineX = new fabric.Line([0, i * gridSize, width * 4, i * gridSize], {
 			objectId: v4(),
 			type: 'line',
 			stroke: '#ccc',
@@ -26,8 +32,18 @@ export const initGrid = (canvas: fabric.Canvas, width: number, height: number, g
 			isSocketObject: false,
 		});
 
-		canvas.sendToBack(lineX);
+		backgroundCanvas.add(lineX);
 	}
+
+	fabric.Image.fromURL(backgroundCanvas.toDataURL(), (img) => {
+		canvas.setBackgroundImage(img, canvas.renderAll.bind(canvas), {
+			objectId: v4(),
+			type: ObjectType.rect,
+			left: -width,
+			top: -height,
+			isSocketObject: false,
+		});
+	});
 };
 
 export const initZoom = (

--- a/frontend/src/utils/fabric.utils.ts
+++ b/frontend/src/utils/fabric.utils.ts
@@ -164,6 +164,7 @@ export const setObjectIndexLeveling = (canvas: fabric.Canvas) => {
 
 export const setCursorMode = (canvas: fabric.Canvas, cursor: string, mode: CanvasType, selectable: boolean) => {
 	canvas.defaultCursor = cursor;
+	canvas.hoverCursor = cursor;
 	canvas.mode = mode;
 	canvas.forEachObject((obj) => (obj.selectable = selectable));
 };

--- a/frontend/src/utils/object.utils.ts
+++ b/frontend/src/utils/object.utils.ts
@@ -1,5 +1,5 @@
 import { fabric } from 'fabric';
-import { ObjectType } from '@pages/workspace/whiteboard-canvas/types';
+import { CanvasType, ObjectType } from '@pages/workspace/whiteboard-canvas/types';
 import { v4 } from 'uuid';
 
 export const setEditMenu = (object: fabric.Object) => {
@@ -107,7 +107,12 @@ export const setPostItEditEvent = (
 	editableTextBox: fabric.Textbox,
 	textBox: fabric.Textbox
 ) => {
+	let prevCanvasMode = 'select' as CanvasType;
+
 	groupObject.on('mousedblclick', (e) => {
+		if (canvas.mode === CanvasType.move) return;
+
+		prevCanvasMode = canvas.mode;
 		textBox.set({ visible: false });
 		canvas.add(editableTextBox);
 		canvas.setActiveObject(editableTextBox);
@@ -128,9 +133,10 @@ export const setPostItEditEvent = (
 	});
 
 	editableTextBox.on('editing:exited', (e) => {
+		console.log(prevCanvasMode);
 		canvas.remove(editableTextBox);
 		textBox.set({ visible: true });
-		canvas.mode = 'select';
+		canvas.mode = prevCanvasMode;
 		textBox.fire('changed');
 	});
 };

--- a/frontend/src/utils/object.utils.ts
+++ b/frontend/src/utils/object.utils.ts
@@ -107,7 +107,7 @@ export const setPostItEditEvent = (
 	editableTextBox: fabric.Textbox,
 	textBox: fabric.Textbox
 ) => {
-	let prevCanvasMode = 'select' as CanvasType;
+	let prevCanvasMode: CanvasType;
 
 	groupObject.on('mousedblclick', (e) => {
 		if (canvas.mode === CanvasType.move) return;
@@ -123,7 +123,7 @@ export const setPostItEditEvent = (
 			width: groupObject.getScaledWidth() * 0.9,
 			fontSize: textBox.fontSize,
 		});
-		canvas.mode = 'edit';
+		canvas.mode = CanvasType.edit;
 		editableTextBox.fire('changed');
 	});
 


### PR DESCRIPTION
### 이슈명
- #176 

### 작업 사항
- move mode에서 편집 모드로 진입할 수 없게 수정
- hover 시 커서 수정

### 참고 사항
- move mode에서 포스트잇을 더블클릭하면 편집모드로 들어가지는데, 이렇게 설정될 경우 게스트인 경우에도 편집할 수 있는 문제가 발생하기 때문에 move mode에서는 편집모드로 들어갈 수 없도록 수정해두었습니다.
- edit 후 다시 원래 커서로 돌아올때 두 가지 방법이 있을 것 같습니다. 커서를 무조건 select로 변경하거나 이전에 사용했던 모드로 돌아가는 방법이 인데요, 커서를 select로 변환하기 위해서는 전역으로 관리하던 state에 접근해서 setState로 수정해야하는데 일반 함수에서는 접근할 수 없으니까 그냥 이전에 사용했던 모드를 기억했다가 돌아가도록 설정해두었습니다.
