### PR TITLE
[feat] 작성자 표시 및 addObject 개선 closes #126

### DIFF
--- a/frontend/src/pages/workspace/whiteboard-canvas/useCanvas.ts
+++ b/frontend/src/pages/workspace/whiteboard-canvas/useCanvas.ts
@@ -14,7 +14,7 @@ import { toolItems } from '@data/workspace-tool';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import { cursorState, zoomState } from '@context/workspace';
 import { CanvasType } from './types';
-import { myInfoInWorkspaceState } from '@context/user';
+import { myInfoInWorkspaceState, userProfileState } from '@context/user';
 import { workspaceRole } from '@data/workspace-role';
 
 function useCanvas() {
@@ -22,6 +22,7 @@ function useCanvas() {
 	const [zoom, setZoom] = useRecoilState(zoomState);
 	const [cursor, setCursor] = useRecoilState(cursorState);
 	const myInfoInWorkspace = useRecoilValue(myInfoInWorkspaceState);
+	const userProfile = useRecoilValue(userProfileState);
 
 	useEffect(() => {
 		if (canvas.current && zoom.event === 'control')
@@ -75,7 +76,7 @@ function useCanvas() {
 		initZoom(fabricCanvas, setZoom);
 		initDragPanning(fabricCanvas);
 		initWheelPanning(fabricCanvas);
-		addObject(fabricCanvas, 'NAME', setCursor);
+		addObject(fabricCanvas, userProfile.nickname, setCursor);
 		deleteObject(fabricCanvas);
 		setObjectIndexLeveling(fabricCanvas);
 

--- a/frontend/src/pages/workspace/whiteboard-canvas/useCanvas.ts
+++ b/frontend/src/pages/workspace/whiteboard-canvas/useCanvas.ts
@@ -57,6 +57,8 @@ function useCanvas() {
 			} else {
 				setCursorMode(fabricCanvas, 'default', CanvasType.draw, true);
 			}
+			canvas.current.discardActiveObject();
+			canvas.current.renderAll();
 		}
 	}, [cursor, myInfoInWorkspace]);
 

--- a/frontend/src/pages/workspace/whiteboard-canvas/useCanvas.ts
+++ b/frontend/src/pages/workspace/whiteboard-canvas/useCanvas.ts
@@ -20,7 +20,7 @@ import { workspaceRole } from '@data/workspace-role';
 function useCanvas() {
 	const canvas = useRef<fabric.Canvas | null>(null);
 	const [zoom, setZoom] = useRecoilState(zoomState);
-	const cursor = useRecoilValue(cursorState);
+	const [cursor, setCursor] = useRecoilState(cursorState);
 	const myInfoInWorkspace = useRecoilValue(myInfoInWorkspaceState);
 
 	useEffect(() => {
@@ -46,9 +46,9 @@ function useCanvas() {
 			setCursorMode(fabricCanvas, 'grab', CanvasType.move, false);
 		} else {
 			if (cursor.type === toolItems.SECTION) {
-				setCursorMode(fabricCanvas, 'context-menu', CanvasType.section, true);
+				setCursorMode(fabricCanvas, 'context-menu', CanvasType.section, false);
 			} else if (cursor.type === toolItems.POST_IT) {
-				setCursorMode(fabricCanvas, 'context-menu', CanvasType.postit, true);
+				setCursorMode(fabricCanvas, 'context-menu', CanvasType.postit, false);
 			} else if (cursor.type === toolItems.MOVE) {
 				setCursorMode(fabricCanvas, 'grab', CanvasType.move, false);
 			} else if (cursor.type === toolItems.SELECT) {
@@ -75,7 +75,7 @@ function useCanvas() {
 		initZoom(fabricCanvas, setZoom);
 		initDragPanning(fabricCanvas);
 		initWheelPanning(fabricCanvas);
-		addObject(fabricCanvas, 'NAME');
+		addObject(fabricCanvas, 'NAME', setCursor);
 		deleteObject(fabricCanvas);
 		setObjectIndexLeveling(fabricCanvas);
 

--- a/frontend/src/pages/workspace/whiteboard-canvas/useCanvasToSocket.ts
+++ b/frontend/src/pages/workspace/whiteboard-canvas/useCanvasToSocket.ts
@@ -56,7 +56,7 @@ function useCanvasToSocket({ canvas, socket }: UseCanvasToSocketProps) {
 		});
 
 		canvas.current.on('text:changed', ({ target }) => {
-			if (!target || target.type !== ObjectType.text) return;
+			if (!target || target.type !== ObjectType.editable) return;
 			const message = formatEditTextEventToSocket(target as fabric.Text);
 			socket.current?.emit('update_object', message);
 		});

--- a/frontend/src/types/fabric-options.d.ts
+++ b/frontend/src/types/fabric-options.d.ts
@@ -15,7 +15,7 @@ interface SectionOption {
 }
 
 interface SectionTitleOptions {
-	editable?: boolean;
+	editable: boolean;
 	objectId: string;
 	text?: string;
 	left: number;
@@ -37,7 +37,7 @@ interface TextBoxOptions {
 	top: number;
 	fontSize: number;
 	text?: string;
-	editable?: boolean;
+	editable: boolean;
 }
 
 interface RectOptions {

--- a/frontend/src/utils/fabric.utils.ts
+++ b/frontend/src/utils/fabric.utils.ts
@@ -4,6 +4,7 @@ import { fabric } from 'fabric';
 import { SetterOrUpdater } from 'recoil';
 import { v4 } from 'uuid';
 import { addPostIt, addSection } from './object.utils';
+import { toolItems } from '@data/workspace-tool';
 
 export const initGrid = (canvas: fabric.Canvas, width: number, height: number, gridSize: number) => {
 	const backgroundCanvas = new fabric.Canvas('', {
@@ -117,7 +118,16 @@ export const initWheelPanning = (canvas: fabric.Canvas) => {
 	});
 };
 
-export const addObject = (canvas: fabric.Canvas, creator: string) => {
+export const addObject = (
+	canvas: fabric.Canvas,
+	creator: string,
+	setCursor: SetterOrUpdater<{
+		type: number;
+		x: number;
+		y: number;
+		color: string;
+	}>
+) => {
 	//todo 색 정보 받아와야함
 	canvas.on('mouse:down', function (opt) {
 		const evt = opt.e;
@@ -127,9 +137,15 @@ export const addObject = (canvas: fabric.Canvas, creator: string) => {
 		const y = (evt.clientY - vpt[5]) / vpt[3];
 		if (canvas.mode === CanvasType.section && !canvas.getActiveObject()) {
 			addSection(canvas, x, y, colorChips[8]);
+			setCursor((prev) => {
+				return { ...prev, type: toolItems.SELECT };
+			});
 		} else if (canvas.mode === CanvasType.postit && !canvas.getActiveObject()) {
 			//todo 색 정보 받아와야함
 			addPostIt(canvas, x, y, 40, colorChips[0], creator);
+			setCursor((prev) => {
+				return { ...prev, type: toolItems.SELECT };
+			});
 		}
 	});
 };

--- a/frontend/src/utils/object-from-server.ts
+++ b/frontend/src/utils/object-from-server.ts
@@ -22,21 +22,21 @@ export const createObjectFromServer = (canvas: fabric.Canvas, newObject: ObjectD
 };
 
 export const createPostitFromServer = (canvas: fabric.Canvas, newObject: ObjectDataFromServer) => {
-	const { objectId, left, top, fontSize, color, text, width, height } = newObject;
+	const { objectId, left, top, fontSize, color, text, width, height, creator } = newObject;
 	if (!left || !top || !fontSize || !color || !text || !width || !height) return;
-	const nameLabel = createNameLabel({ objectId, text: 'NAME', left, top });
+	const nameLabel = createNameLabel({ objectId, text: creator, left, top });
 	const textBox = createTextBox({ objectId, left, top, fontSize, text, editable: false });
 	const editableTextBox = createTextBox({ objectId, left, top, fontSize, text, editable: true });
 
 	const backgroundRect = createRect({ objectId, left, top, color });
 	backgroundRect.set({
-		width,
-		height,
+		// width,
+		// height,
 		isSocketObject: true,
 	});
 	textBox.set({
-		width,
-		height,
+		// width,
+		// height,
 		isSocketObject: true,
 	});
 	nameLabel.set({

--- a/frontend/src/utils/object-from-server.ts
+++ b/frontend/src/utils/object-from-server.ts
@@ -25,8 +25,8 @@ export const createPostitFromServer = (canvas: fabric.Canvas, newObject: ObjectD
 	const { objectId, left, top, fontSize, color, text, width, height } = newObject;
 	if (!left || !top || !fontSize || !color || !text || !width || !height) return;
 	const nameLabel = createNameLabel({ objectId, text: 'NAME', left, top });
-	const textBox = createTextBox({ objectId, left, top, fontSize, text });
-	const editableTextBox = createTextBox({ objectId, left, top, fontSize, text });
+	const textBox = createTextBox({ objectId, left, top, fontSize, text, editable: false });
+	const editableTextBox = createTextBox({ objectId, left, top, fontSize, text, editable: true });
 
 	const backgroundRect = createRect({ objectId, left, top, color });
 	backgroundRect.set({

--- a/frontend/src/utils/object.utils.ts
+++ b/frontend/src/utils/object.utils.ts
@@ -173,7 +173,7 @@ export const addPostIt = (
 ) => {
 	const id = v4();
 	const nameLabel = createNameLabel({ objectId: id, text: creator, left: x, top: y });
-	const textBox = createTextBox({ objectId: id, left: x, top: y, fontSize: fontSize });
+	const textBox = createTextBox({ objectId: id, left: x, top: y, fontSize: fontSize, editable: false });
 	const editableTextBox = createTextBox({ objectId: id, left: x, top: y, fontSize: 40, editable: true });
 	const backgroundRect = createRect({ objectId: id, left: x, top: y, color: fill });
 	const postit = createPostIt({
@@ -296,7 +296,7 @@ export const setSectionEditEvent = (
 export const addSection = (canvas: fabric.Canvas, x: number, y: number, fill: string) => {
 	const id = v4();
 	const editableTitle = createSectionTitle({ objectId: id, text: 'SECTION', left: x, top: y + 25, editable: true });
-	const sectionTitle = createSectionTitle({ objectId: id, text: 'SECTION', left: x, top: y });
+	const sectionTitle = createSectionTitle({ objectId: id, text: 'SECTION', left: x, top: y, editable: false });
 	const sectionBackground = createTitleBackground({ objectId: id, left: x, top: y, color: fill });
 	const backgroundRect = createRect({ objectId: id, left: x, top: y, color: fill });
 	const section = createSection({


### PR DESCRIPTION
### 이슈명
- #127
- #126 

### 작업내용
- 오브젝트 위에 오브젝트 추가 가능
- 오브젝트 추가 하고나면 Select 모드로 변경
- PostIt 작성자 표시
- 서버에서 받아온 Object가 사라지는 버그 수정
- 서버에서 받아온 Obejct width, height 설정 주석처리

### 캡처화면
![addobejct1](https://user-images.githubusercontent.com/72279836/204995665-8e8b3b22-25f9-463f-944c-7e48d9f026c5.gif)


### 추가사항
- postit.set({scaleX, scaleY})로 설정해주면 자동으로 PostIt 사이즈 동기화 될 겁니다. (아니면 유감...)