### PR TITLE
[fix] scale-object 이벤트 요청 응답 데이터 구조 변경 #161

### DIFF
--- a/backend/src/socket/dto/object-scale.dto.ts
+++ b/backend/src/socket/dto/object-scale.dto.ts
@@ -4,15 +4,21 @@ export class ObjectScaleDTO {
   @IsString()
   objectId: string;
 
-  @IsNumber()
-  dleft: number;
+  // @IsNumber()
+  // dleft: number;
+  //
+  // @IsNumber()
+  // dtop: number;
 
   @IsNumber()
-  dtop: number;
+  left: number;
 
   @IsNumber()
-  scaleX;
+  top: number;
 
   @IsNumber()
-  scaleY;
+  scaleX: number;
+
+  @IsNumber()
+  scaleY: number;
 }

--- a/backend/src/socket/socket.gateway.ts
+++ b/backend/src/socket/socket.gateway.ts
@@ -227,10 +227,8 @@ export class SocketGateway implements OnGatewayInit, OnGatewayConnection, OnGate
       userId: userData.userId,
       objectData: {
         objectId: objectScaleDTO.objectId,
-        dleft: objectScaleDTO.dleft,
-        dtop: objectScaleDTO.dtop,
-        left: objectData.left,
-        top: objectData.top,
+        left: objectScaleDTO.left,
+        top: objectScaleDTO.top,
         scaleX: objectScaleDTO.scaleX,
         scaleY: objectScaleDTO.scaleY,
       },


### PR DESCRIPTION
## 관련 이슈
- #161 

## 작업 내용
- ObjectScaleDTO에서 dleft와 dtop을 제거하고, left와 top을 추가함.
- 이벤트 emit 시 left와 top을 client에서 제공하는 값을 제공하도록 변경
- 이벤트 emit 시 dleft, dtop을 제공하지 않음