### PR TITLE
[feat]  Role 권한 수정 Event Handler 추가 closes #216

### DIFF
--- a/backend/src/socket/dto/change-role.dto.ts
+++ b/backend/src/socket/dto/change-role.dto.ts
@@ -6,7 +6,7 @@ export class ChangeUserRoleDTO {
   userId: string;
 
   @Min(WORKSPACE_ROLE.VIEWER)
-  @Max(WORKSPACE_ROLE.OWNER)
+  @Max(WORKSPACE_ROLE.EDITOR)
   @IsNumber()
   role: number;
 }

--- a/backend/src/socket/dto/change-role.dto.ts
+++ b/backend/src/socket/dto/change-role.dto.ts
@@ -1,0 +1,12 @@
+import { IsString, IsNumber, Max, Min } from 'class-validator';
+import { WORKSPACE_ROLE } from 'src/util/constant/role.constant';
+
+export class ChangeUserRoleDTO {
+  @IsString()
+  userId: string;
+
+  @Min(WORKSPACE_ROLE.VIEWER)
+  @Max(WORKSPACE_ROLE.OWNER)
+  @IsNumber()
+  role: number;
+}

--- a/backend/src/socket/socket.gateway.ts
+++ b/backend/src/socket/socket.gateway.ts
@@ -268,7 +268,7 @@ export class SocketGateway implements OnGatewayInit, OnGatewayConnection, OnGate
   @SubscribeMessage('change_role')
   @UseGuards(UserRoleGuard(WORKSPACE_ROLE.OWNER))
   async changeUserRole(
-    @MessageBody(new ValidationPipe()) { userId, role }: ChangeUserRoleDTO,
+    @MessageBody(new ValidationPipe({ exceptionFactory: errorMsgFormatter })) { userId, role }: ChangeUserRoleDTO,
     @ConnectedSocket() socket: Socket,
   ) {
     const { workspaceId } = this.dataManagementService.findUserDataBySocketId(socket.id);


### PR DESCRIPTION
## 관련 이슈
- #216 
## 작업 사항
- Role 권한 상승 Event Handler 추가. (`Owner` 권한만 가능. 부여 가능한 권한은 `Viewer`와 `Editor`임.)
- Db 접근용 Service에 DB 권한 수정 메서드 추가