### PR TITLE
[chore] background 깜빡임 현상 수정 closes #228

### DIFF
--- a/frontend/src/pages/workspace/whiteboard-canvas/index.style.tsx
+++ b/frontend/src/pages/workspace/whiteboard-canvas/index.style.tsx
@@ -6,3 +6,10 @@ export const WhiteboardCanvasLayout = styled.div`
 	top: 0;
 	z-index: 0;
 `;
+
+export const LoadingContainer = styled.div`
+	position: relative;
+	width: 100vw;
+	height: 100vh;
+	background: #f1f1f1;
+`;

--- a/frontend/src/pages/workspace/whiteboard-canvas/index.tsx
+++ b/frontend/src/pages/workspace/whiteboard-canvas/index.tsx
@@ -1,4 +1,4 @@
-import { WhiteboardCanvasLayout } from './index.style';
+import { LoadingContainer, WhiteboardCanvasLayout } from './index.style';
 import useCanvas from './useCanvas';
 import useSocket from './useSocket';
 import ContextMenu from '@components/context-menu';
@@ -8,10 +8,11 @@ import useCanvasToSocket from './useCanvasToSocket';
 import { myInfoInWorkspaceState } from '@context/user';
 import { workspaceRole } from '@data/workspace-role';
 import useRoleEvent from './useRoleEvent';
+import Loading from '@components/loading';
 
 function WhiteboardCanvas() {
 	const { canvas } = useCanvas();
-	const { socket } = useSocket(canvas);
+	const { socket, isEndInit } = useSocket(canvas);
 
 	const { isOpen, menuRef, color, setObjectColor, fontSize, handleFontSize, selectedType, menuPosition } =
 		useCanvasToSocket({ canvas, socket });
@@ -34,6 +35,12 @@ function WhiteboardCanvas() {
 						setFontSize={handleFontSize}
 					/>
 				</ContextMenu>
+			)}
+
+			{!isEndInit && (
+				<LoadingContainer>
+					<Loading />
+				</LoadingContainer>
 			)}
 		</>
 	);

--- a/frontend/src/pages/workspace/whiteboard-canvas/useSocket.ts
+++ b/frontend/src/pages/workspace/whiteboard-canvas/useSocket.ts
@@ -24,6 +24,7 @@ function useSocket(canvas: React.MutableRefObject<fabric.Canvas | null>) {
 	const socket = useRef<Socket<ServerToClientEvents, ClientToServerEvents> | null>(null);
 	const membersInCanvas = useRef<MemberInCanvas[]>([]);
 	const [isConnected, setIsConnected] = useState(false);
+	const [isEndInit, setIsEndInit] = useState(false);
 
 	const { workspaceId } = useParams();
 
@@ -71,6 +72,8 @@ function useSocket(canvas: React.MutableRefObject<fabric.Canvas | null>) {
 				const role = myInfoInWorkspaceRef.current?.role as Role;
 				createObjectFromServer(canvas.current, object, role);
 			});
+
+			setIsEndInit(true);
 		});
 
 		socket.current.on('enter_user', (userData) => {
@@ -156,6 +159,7 @@ function useSocket(canvas: React.MutableRefObject<fabric.Canvas | null>) {
 
 	return {
 		isConnected,
+		isEndInit,
 		socket,
 		membersInCanvas,
 	};

--- a/frontend/src/utils/fabric.utils.ts
+++ b/frontend/src/utils/fabric.utils.ts
@@ -41,8 +41,7 @@ export const initGrid = (canvas: fabric.Canvas, patternSize: number, gridSize: n
 		source: backgroundCanvas.toDataURL(),
 	});
 
-	canvas.backgroundColor = backgroundPattern;
-	canvas.requestRenderAll();
+	canvas.setBackgroundColor(backgroundPattern, () => canvas.renderAll());
 };
 
 export const initZoom = (


### PR DESCRIPTION
### 이슈명
- #228 

### 작업 사항
- init이 완료된 뒤 canvas가 뜨도록 설정

### 참고 사항
- Pattern을 background로 얹는 작업이 시간이 많이 걸리는지 fabric 내에서 해결하려고 했는데 해결이 안돼서 init이 완료되고 모든 오브젝트가 있는 화면을 사용자가 볼 수 있도록 상태를 하나 더 추가해주었습니다.