### PR TITLE
[feat] mouse cursor batching + webworker 최적화

### DIFF
--- a/frontend/src/pages/workspace/whiteboard-canvas/index.tsx
+++ b/frontend/src/pages/workspace/whiteboard-canvas/index.tsx
@@ -10,13 +10,17 @@ import { workspaceRole } from '@data/workspace-role';
 import useRoleEvent from './useRoleEvent';
 import ExportModal from '../export-modal';
 import Loading from '@components/loading';
+import ObjectWorker from 'worker/object.worker';
+import CursorWorker from 'worker/cursor.worker';
+import useCursorWorker from './useCursorWorker';
 
 function WhiteboardCanvas() {
 	const { canvas } = useCanvas();
 	const { socket, isEndInit } = useSocket(canvas);
+	const { worker: cursorWorker } = useCursorWorker(CursorWorker, socket);
 
 	const { isOpen, menuRef, color, setObjectColor, fontSize, handleFontSize, selectedType, menuPosition } =
-		useCanvasToSocket({ canvas, socket });
+		useCanvasToSocket({ canvas, socket, cursorWorker });
 	useRoleEvent(socket);
 	const myInfoInWorkspace = useRecoilValue(myInfoInWorkspaceState);
 

--- a/frontend/src/pages/workspace/whiteboard-canvas/useCanvasToSocket.ts
+++ b/frontend/src/pages/workspace/whiteboard-canvas/useCanvasToSocket.ts
@@ -22,9 +22,10 @@ import { isNull, isUndefined } from '@utils/type.utils';
 interface UseCanvasToSocketProps {
 	canvas: React.MutableRefObject<fabric.Canvas | null>;
 	socket: React.MutableRefObject<Socket<ServerToClientEvents, ClientToServerEvents> | null>;
+	cursorWorker: React.MutableRefObject<Worker | undefined>;
 }
 
-function useCanvasToSocket({ canvas, socket }: UseCanvasToSocketProps) {
+function useCanvasToSocket({ canvas, socket, cursorWorker }: UseCanvasToSocketProps) {
 	const { isOpen, menuRef, color, setObjectColor, fontSize, handleFontSize, openMenu, selectedType, menuPosition } =
 		useEditMenu(canvas);
 
@@ -186,8 +187,15 @@ function useCanvasToSocket({ canvas, socket }: UseCanvasToSocketProps) {
 				x,
 				y,
 			};
-			socket.current?.emit('move_pointer', message);
+			cursorWorker.current?.postMessage(message);
+			// socket.current?.emit('move_pointer', message);
 		});
+		return () => {
+			if (socket.current) {
+				console.log(canvas.current);
+				socket.current?.emit('update_object', { objectId: 'asdasdas' });
+			}
+		};
 	}, []);
 
 	return {

--- a/frontend/src/pages/workspace/whiteboard-canvas/useCursorWorker.ts
+++ b/frontend/src/pages/workspace/whiteboard-canvas/useCursorWorker.ts
@@ -1,0 +1,46 @@
+import { useRef, useEffect } from 'react';
+import { isUndefined } from '@utils/type.utils';
+import { ServerToClientEvents, ClientToServerEvents } from './types';
+import { Socket } from 'socket.io-client';
+import { MousePointer } from '@pages/workspace/whiteboard-canvas/types';
+
+function useCursorWorker(
+	workerModule: () => void,
+	socket: React.MutableRefObject<Socket<ServerToClientEvents, ClientToServerEvents> | null>
+) {
+	const worker = useRef<Worker>();
+
+	const initWorker = () => {
+		const code = workerModule.toString();
+		console.log(code);
+		const blob = new Blob([`(${code})()`]);
+		return new Worker(URL.createObjectURL(blob));
+	};
+
+	useEffect(() => {
+		worker.current = initWorker();
+		worker.current.onmessage = ({
+			data: { mouse, queueLength },
+		}: {
+			data: { mouse: MousePointer; queueLength: number };
+		}) => {
+			console.log(queueLength);
+			socket.current?.emit('move_pointer', mouse);
+		};
+
+		worker.current.onerror = (error) => {
+			console.log(error);
+		};
+
+		return () => {
+			if (isUndefined(worker.current)) return;
+			worker.current.terminate();
+		};
+	}, []);
+
+	return {
+		worker,
+	};
+}
+
+export default useCursorWorker;

--- a/frontend/src/worker/cursor.worker.ts
+++ b/frontend/src/worker/cursor.worker.ts
@@ -1,0 +1,26 @@
+import { MousePointer } from '@pages/workspace/whiteboard-canvas/types';
+
+export default () => {
+	let waitQueue: MousePointer[] = [];
+
+	self.onmessage = ({ data }: { data: MousePointer }) => {
+		waitQueue.push(data);
+	};
+
+	setInterval(() => {
+		const data = batchQueue();
+		if (data) {
+			self.postMessage(data);
+		}
+	}, 33.4);
+
+	const batchQueue = () => {
+		if (waitQueue.length === 0) return;
+		const taskQueue = waitQueue;
+		waitQueue = [];
+		return {
+			mouse: taskQueue[taskQueue.length - 1],
+			queueLength: taskQueue.length,
+		};
+	};
+};

--- a/frontend/src/worker/object.worker.ts
+++ b/frontend/src/worker/object.worker.ts
@@ -1,0 +1,5 @@
+export default () => {
+	setInterval(() => {
+		postMessage(Date.now());
+	}, 1000);
+};


### PR DESCRIPTION
## issue
- closes #244 
## 공유사항
- 30fps에 맞춰서 33ms마다 마우스커서 이동 이벤트를 배치처리해서 전송했습니다.
- 연산을 webworker에서 처리했습니다
- 기존 3~ 4번 -> 1번으로 이벤트수가 절감했습니다