### PR TITLE
[feat] updating_object 이벤트 구현 closes #262

### DIFF
--- a/backend/src/socket/pipe/object-updating.pipe.ts
+++ b/backend/src/socket/pipe/object-updating.pipe.ts
@@ -1,0 +1,22 @@
+import { ArgumentMetadata, Injectable, PipeTransform } from '@nestjs/common';
+import { WsException } from '@nestjs/websockets';
+import { CreateObjectDTO } from 'src/object-database/dto/create-object.dto';
+import { UpdateObjectDTO } from 'src/object-database/dto/update-object.dto';
+
+const isNullOrUndefined = (v: any): boolean => v === null || v === undefined;
+
+/**
+ * Validation Pipe를 거친 Object Dto에 대해 추가적인 수정을 가합니다.
+ */
+@Injectable()
+export class ObjectUpdatingPipe {
+  transform(value: any, metadata: ArgumentMetadata) {
+    switch (metadata.metatype) {
+      case UpdateObjectDTO:
+        break;
+      default:
+        throw new Error('잘못된 사용법입니다. UpdateObjectDTO에 대해서만 사용해주시기 바랍니다.');
+    }
+    return value;
+  }
+}

--- a/backend/src/socket/socket.gateway.ts
+++ b/backend/src/socket/socket.gateway.ts
@@ -28,6 +28,7 @@ import { ObjectTransformPipe } from './pipe/object-transform.pipe';
 import { ValidationError } from 'class-validator';
 import { UserRoleGuard } from './guard/user-role.guard';
 import { ChangeUserRoleDTO } from './dto/change-role.dto';
+import { ObjectUpdatingPipe } from './pipe/object-updating.pipe';
 
 const errorMsgFormatter = (errors: ValidationError[]) =>
   new WsException(`잘못된 속성 전달: ${errors.map((e) => e.property).join(', ')}`);
@@ -290,10 +291,11 @@ export class SocketGateway implements OnGatewayInit, OnGatewayConnection, OnGate
   @SubscribeMessage('updating_object')
   @UseGuards(UserRoleGuard(WORKSPACE_ROLE.EDITOR))
   async updatingObject(
-    @MessageBody(new ValidationPipe({ exceptionFactory: errorMsgFormatter }), new ObjectTransformPipe())
+    @MessageBody(new ValidationPipe({ exceptionFactory: errorMsgFormatter }), new ObjectUpdatingPipe())
     objectData: UpdateObjectDTO,
     @ConnectedSocket() socket: Socket,
   ) {
+    console.log(objectData);
     const userData = this.dataManagementService.findUserDataBySocketId(socket.id);
     socket.nsp.emit('updating_object', { userId: userData.userId, objectData });
 

--- a/backend/src/socket/socket.gateway.ts
+++ b/backend/src/socket/socket.gateway.ts
@@ -286,4 +286,19 @@ export class SocketGateway implements OnGatewayInit, OnGatewayConnection, OnGate
 
     socket.nsp.emit('change_role', { userId, role });
   }
+
+  @SubscribeMessage('updating_object')
+  @UseGuards(UserRoleGuard(WORKSPACE_ROLE.EDITOR))
+  async updatingObject(
+    @MessageBody(new ValidationPipe({ exceptionFactory: errorMsgFormatter }), new ObjectTransformPipe())
+    objectData: UpdateObjectDTO,
+    @ConnectedSocket() socket: Socket,
+  ) {
+    const userData = this.dataManagementService.findUserDataBySocketId(socket.id);
+    socket.nsp.emit('updating_object', { userId: userData.userId, objectData });
+
+    this.logger.log(
+      `workspaceId: ${socket.nsp.name.substring(11)} / eventName: updating_object / userId: ${userData.userId}`,
+    );
+  }
 }

--- a/backend/src/socket/socket.gateway.ts
+++ b/backend/src/socket/socket.gateway.ts
@@ -295,7 +295,6 @@ export class SocketGateway implements OnGatewayInit, OnGatewayConnection, OnGate
     objectData: UpdateObjectDTO,
     @ConnectedSocket() socket: Socket,
   ) {
-    console.log(objectData);
     const userData = this.dataManagementService.findUserDataBySocketId(socket.id);
     socket.nsp.emit('updating_object', { userId: userData.userId, objectData });
 


### PR DESCRIPTION
### 이슈명

BE - Object Update 관련 범용 이벤트 추가

### 작업사항

- `updating_object` 이벤트 구현

## 참고사항

UpdateObjectDTO는 그대로 두고 pipe를 하나 더 만들었습니다.
기존 사용하던 UpdateObjectDTO도 type은 optional인데 transform-pipe에서 type을 통해 검증을 하기 때문에 필수적이였던 것인데, 지금은 기존 dto는 써도 될 것 같아서 pipe를 별도로 추가하였습니다.