### PR TITLE
[feat] 텍스트 공동 편집 closes #273

### DIFF
--- a/frontend/src/utils/object-from-server.ts
+++ b/frontend/src/utils/object-from-server.ts
@@ -263,11 +263,11 @@ export const updateObjectFromServer = (canvas: fabric.Canvas, updatedObject: Obj
 		editableText.fire('changed');
 
 		rectObject.set({ ...updatedObject });
-	} else {
-		object.forEach((obj) => {
-			updateObject(obj, updatedObject);
-		});
 	}
+
+	object.forEach((obj) => {
+		updateObject(obj, updatedObject);
+	});
 };
 
 export const selectObjectFromServer = (canvas: fabric.Canvas, objectIds: string[], color: string) => {

--- a/frontend/src/utils/object-from-server.ts
+++ b/frontend/src/utils/object-from-server.ts
@@ -240,9 +240,9 @@ export const updateObjectFromServer = (canvas: fabric.Canvas, updatedObject: Obj
 	const { type, ...updatedProperty } = updatedObject;
 
 	if (object[0].type === ObjectType.editable) {
-		const [editableText, rectObject] = object;
-		let left = editableText.left,
-			top = editableText.top;
+		const [editableObject, rectObject] = object;
+		let left = editableObject.left,
+			top = editableObject.top;
 		const width = rectObject.getScaledWidth() * 0.9;
 
 		if (rectObject.type === ObjectType.postit) {
@@ -252,15 +252,18 @@ export const updateObjectFromServer = (canvas: fabric.Canvas, updatedObject: Obj
 			left = updatedProperty.left ? updatedProperty.left + rectObject.getScaledWidth() * 0.05 : left;
 		}
 
+		const editableText = editableObject as fabric.Textbox;
 		editableText.set({
 			left,
 			top,
 			width,
+			text: (updatedProperty.text || editableText.text) as string,
 		});
+		(editableText.hiddenTextarea as HTMLTextAreaElement).value = (updatedProperty.text || editableText.text) as string;
+		editableText.fire('changed');
 
 		rectObject.set({ ...updatedObject });
 	} else {
-		console.log(object);
 		object.forEach((obj) => {
 			updateObject(obj, updatedObject);
 		});

--- a/frontend/src/utils/object.utils.ts
+++ b/frontend/src/utils/object.utils.ts
@@ -338,13 +338,14 @@ export const setSectionEditEvent = (
 		sectionTitle.set({ visible: false });
 		canvas.add(editableTitle);
 		canvas.setActiveObject(editableTitle);
-		editableTitle.enterEditing();
 		editableTitle.set({
 			scaleX: groupObject.scaleX,
 			scaleY: groupObject.scaleY,
 			left: (groupObject?.left || 0) + 10 * (groupObject?.scaleX || 1),
 			top: groupObject.top,
+			text: sectionTitle.text,
 		});
+		editableTitle.enterEditing();
 
 		canvas.mode = CanvasType.edit;
 	});


### PR DESCRIPTION
### 이슈명
- #273 

### 작업 사항
- 포스트잇 텍스트 공동 편집

### 참고 사항
- 포스트잇의 타입은 TextBox로 내부의 textarea까지 수정해야 공동 편집 상태가 정상적으로 작동하더라구요.
- 근데 섹션의 타이틀은 IText로 Textbox처럼 내부에 textarea를 사용하던데 막상 IText의 textarea를 수정하려 하니까 값이 없다고 떠서 수정이 안되네요,,?