### PR TITLE
fix: be - 생성 및 초기화 시에 id를 닉네임으로 치환 #286

### DIFF
--- a/backend/src/socket/socket.gateway.ts
+++ b/backend/src/socket/socket.gateway.ts
@@ -116,6 +116,7 @@ export class SocketGateway implements OnGatewayInit, OnGatewayConnection, OnGate
         );
     }
 
+    this.dbAccessService.replaceCreatorIdToNickname(workspaceId, objects);
     this.logger.log(`workspaceId: ${workspaceId} / eventName: handleConnection / userId: ${userMapVO.userId}`);
   }
 
@@ -253,6 +254,7 @@ export class SocketGateway implements OnGatewayInit, OnGatewayConnection, OnGate
 
       // 생성을 시도하고, 성공하면 이를 전달한다.
       await this.objectManagementService.insertObjectIntoWorkspace(userData.workspaceId, objectData);
+      objectData.creator = userData.nickname;
       socket.nsp.emit('create_object', objectData);
 
       this.logger.log(


### PR DESCRIPTION
## 관련 이슈
- #286 
## 작업 사항
- init 및 create 시에 서버가 클라이언트에게 전달해주는 object 목록에서 creator 값을 id에서 nickname으로 치환하는 작업을 수행함.