### PR TITLE
[fix] draw object index leveling closes #271

### DIFF
--- a/frontend/src/utils/fabric.utils.ts
+++ b/frontend/src/utils/fabric.utils.ts
@@ -202,6 +202,7 @@ export const setObjectIndexLeveling = (canvas: fabric.Canvas) => {
 		drawings.forEach((obj) => {
 			obj.bringToFront();
 		});
+		e.target?.bringToFront();
 	});
 };
 


### PR DESCRIPTION
# 이슈명
- #271

# 작업내용
- 조금 이상하지만 강제로 draw object를 맨 위로 올렸음
- draw는 항상 맨 위에 위치시킴